### PR TITLE
Allow opening an IPA bundle file directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +198,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +235,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -339,6 +373,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "once_cell"
@@ -616,6 +659,7 @@ dependencies = [
  "touchHLE_gl_bindings",
  "touchHLE_openal_soft_wrapper",
  "touchHLE_stb_image_wrapper",
+ "zip",
 ]
 
 [[package]]
@@ -719,3 +763,15 @@ name = "xml-rs"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+
+[[package]]
+name = "zip"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0445d0fbc924bb93539b4316c11afb121ea39296f99a3c4c9edad09e3658cdef"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ caf = "0.1.0"
 hound = "3.5.0"
 mach_object = "0.1.17"
 plist = "1.3.1"
+zip = { version = "0.6.4", default-features = false, features = ["deflate"] }
 rusttype = "0.9.3"
 # sdl2 crates pinned at 0.35.1 because static linking seems to be broken for
 # 0.35.2 on macOS (build errors about undefined symbols for

--- a/src/fs/bundle.rs
+++ b/src/fs/bundle.rs
@@ -1,0 +1,232 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+//! IPA file format support, allowing it to be used as part of the guest filesystem.
+use crate::fs::{FsNode, GuestPath};
+use std::cell::RefCell;
+use std::fmt::Debug;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use zip::result::ZipError;
+use zip::ZipArchive;
+
+/// A helper struct to build an FsNode with files and directories coming in arbitrary order.
+/// This is required, because ZIP files are allowed to store entries in arbitrary order.
+struct FsNodeBuilder {
+    root: FsNode,
+}
+
+impl FsNodeBuilder {
+    fn new() -> Self {
+        Self {
+            root: FsNode::dir(),
+        }
+    }
+
+    fn find_or_make_directory(&mut self, path: &GuestPath) -> &mut FsNode {
+        let mut current = &mut self.root;
+        for part in path.as_str().split('/') {
+            if part.is_empty() {
+                continue;
+            }
+            assert_ne!(part, "..", "unexpected .. in path: {path:?}");
+            let FsNode::Directory { children, .. } = current else {
+                panic!("expected directory, got {current:?}");
+            };
+
+            let next = children.entry(part.to_string()).or_insert_with(FsNode::dir);
+            current = next;
+        }
+        current
+    }
+
+    fn add_file(&mut self, path: &GuestPath, node: FsNode) {
+        let (parent_name, file_name) = path.parent_and_file_name().unwrap();
+        assert_ne!(file_name, "..", "unexpected .. in path: {path:?}");
+        let dir = self.find_or_make_directory(parent_name);
+        let FsNode::Directory { children, .. } = dir else {
+            panic!("expected directory, got {dir:?}");
+        };
+
+        children.insert(file_name.to_string(), node);
+    }
+
+    fn add_directory(&mut self, path: &GuestPath) {
+        self.find_or_make_directory(path);
+    }
+
+    fn build(self) -> FsNode {
+        self.root
+    }
+}
+
+/// Represents an open app bundle, either a directory or a zip file.
+pub enum BundleData {
+    HostDirectory(PathBuf),
+    Zip {
+        zip: ZipArchive<std::fs::File>,
+        /// Path to the app bundle inside the zip file.
+        /// It should be "Payload/<app name>.app" (no trailing slash!).
+        bundle_path: String,
+    },
+}
+
+impl BundleData {
+    fn find_bundle_path_in_archive(zip: &mut ZipArchive<std::fs::File>) -> Result<String, String> {
+        for i in 0..zip.len() {
+            let file = zip
+                .by_index(i)
+                .map_err(|e| format!("Could not open IPA archive entry: {e}"))?;
+            let path = file.name();
+            if let Some(name) = path
+                .strip_prefix("Payload/")
+                .and_then(|path| path.split_once('/'))
+                .and_then(|(name, _)| name.strip_suffix(".app"))
+            {
+                return Ok(format!("Payload/{name}.app"));
+            }
+        }
+        Err("no app bundle found in the IPA archive".to_string())
+    }
+
+    pub fn open_host_dir(path: &Path) -> Result<BundleData, String> {
+        Ok(BundleData::HostDirectory(path.to_path_buf()))
+    }
+
+    pub fn open_ipa(path: &Path) -> Result<BundleData, String> {
+        let file =
+            std::fs::File::open(path).map_err(|e| format!("Could not open IPA file: {e}"))?;
+        let mut zip =
+            ZipArchive::new(file).map_err(|e| format!("Could not open IPA archive: {e}"))?;
+        let bundle_path = Self::find_bundle_path_in_archive(&mut zip)?;
+        Ok(BundleData::Zip { zip, bundle_path })
+    }
+
+    pub fn open_any(path: &Path) -> Result<BundleData, String> {
+        if path.is_file()
+            && path
+                .extension()
+                .map(|ext| ext.eq_ignore_ascii_case("ipa"))
+                .unwrap_or(false)
+        {
+            Ok(Self::open_ipa(path)?)
+        } else if path.is_dir() {
+            Ok(Self::open_host_dir(path)?)
+        } else {
+            Err(format!(
+                "{} is not a directory or an IPA file",
+                path.display()
+            ))
+        }
+    }
+
+    pub(super) fn into_fs_node(self) -> FsNode {
+        match self {
+            BundleData::HostDirectory(path) => FsNode::from_host_dir(&path, false),
+            BundleData::Zip { zip, bundle_path } => {
+                let archive = Rc::new(RefCell::new(zip));
+
+                let mut archive_guard = (*archive).borrow_mut();
+
+                let mut builder = FsNodeBuilder::new();
+                for i in 0..archive_guard.len() {
+                    let file = archive_guard.by_index(i).unwrap(); // TODO: report IO error?
+                    let name = file.name();
+                    if let Some(path) = name.strip_prefix(&bundle_path) {
+                        let path = GuestPath::new(path);
+                        if file.is_dir() {
+                            builder.add_directory(path);
+                        } else {
+                            builder.add_file(
+                                path,
+                                FsNode::bundle_zip_file(IpaFileRef {
+                                    archive: archive.clone(),
+                                    index: i,
+                                }),
+                            );
+                        }
+                    }
+                }
+                builder.build()
+            }
+        }
+    }
+
+    pub fn read_plist(&mut self) -> Result<Vec<u8>, String> {
+        match self {
+            BundleData::HostDirectory(path) => {
+                std::fs::read(path.join("Info.plist")).map_err(|e| {
+                    format!("Could not read Info.plist from the app bundle directory: {e}")
+                })
+            }
+            BundleData::Zip { zip, bundle_path } => {
+                let mut file = zip
+                    .by_name(&format!("{bundle_path}/Info.plist"))
+                    .map_err(|e| format!("Could not open Info.plist from the IPA archive: {e}"))?;
+                let mut buf = Vec::new();
+                file.read_to_end(&mut buf)
+                    .map_err(|e| format!("Could not read Info.plist from the IPA archive: {e}"))?;
+                Ok(buf)
+            }
+        }
+    }
+}
+
+/// Represents a file inside an IPA bundle that can be opened.
+#[derive(Debug)]
+pub struct IpaFileRef {
+    archive: Rc<RefCell<ZipArchive<std::fs::File>>>,
+    index: usize,
+}
+
+impl IpaFileRef {
+    pub fn open(&self) -> IpaFile {
+        let mut archive = (*self.archive).borrow_mut();
+        let mut file = match archive.by_index(self.index) {
+            Ok(file) => file,
+            Err(ZipError::Io(e)) => {
+                // this is a runtime error, which we __probably__ should not bubble up to the guest
+                panic!("IO error while opening file from IPA bundle: {e}")
+            }
+            // anything other than IO error is a bug in the code, we should always have a valid index
+            Err(e) => panic!("BUG: could not open file from IPA bundle: {e}"),
+        };
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf).unwrap();
+        IpaFile {
+            file: std::io::Cursor::new(buf),
+        }
+    }
+}
+
+/// Represents an opened file in an IPA bundle.
+pub struct IpaFile {
+    // we need to use a cursor because zip::read::ZipFile doesn't implement Seek
+    // and, generally, seeking in compressed files is hard to achieve
+    // the simplest way to do it is to read the whole file into memory
+    // the target apps should be small enough to fit in memory, right?
+    file: std::io::Cursor<Vec<u8>>,
+}
+
+impl Debug for IpaFile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IpaFile")
+            .field("size", &self.file.get_ref().len())
+            .finish()
+    }
+}
+
+impl Read for IpaFile {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.file.read(buf)
+    }
+}
+
+impl std::io::Seek for IpaFile {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        self.file.seek(pos)
+    }
+}

--- a/src/libc/stdio.rs
+++ b/src/libc/stdio.rs
@@ -28,7 +28,7 @@ struct FILE {
 unsafe impl SafeRead for FILE {}
 
 struct FileHostObject {
-    file: std::fs::File,
+    file: crate::fs::GuestFile,
 }
 
 fn fopen(env: &mut Environment, filename: ConstPtr<u8>, mode: ConstPtr<u8>) -> MutPtr<FILE> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,10 +282,12 @@ impl Environment {
     fn new(bundle_path: PathBuf, options: Options) -> Result<Environment, String> {
         let startup_time = std::time::Instant::now();
 
-        let (bundle, fs) = match bundle::Bundle::new_bundle_and_fs_from_host_path(bundle_path) {
+        let bundle_data = fs::BundleData::open_any(&bundle_path)
+            .map_err(|e| format!("Could not open app bundle: {e}"))?;
+        let (bundle, fs) = match bundle::Bundle::new_bundle_and_fs_from_host_path(bundle_data) {
             Ok(bundle) => bundle,
             Err(err) => {
-                return Err(format!("Application bundle error: {}. Check that the path is to a .app directory. If this is a .ipa file, you need to extract it as a ZIP file to get the .app directory.", err));
+                return Err(format!("Application bundle error: {err}. Check that the path is to an .app directory or an .ipa file."));
             }
         };
 


### PR DESCRIPTION
Closes #20

It works, but I am not yet happy about all the code. 
The error handling is kind of all over the place.
Also, maybe it's worth making a `FileRef` enum representing "a file that can potentially be opened" instead of two variants in `FsNode` enum