### PR TITLE
Allow launching apps that do initialization in code, fix "Could not read icon file" issue, and implement exit()

### DIFF
--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -83,13 +83,17 @@ impl Bundle {
         }
     }
 
-    pub fn main_nib_file_path(&self) -> GuestPathBuf {
-        // FIXME: There might not be a main nib file, or it might be localised
+    pub fn main_nib_file_path(&self) -> Option<GuestPathBuf> {
+        // FIXME: The main nib file might be localised
         // and have multiple paths. This method should definitely be removed
         // eventually.
-        self.path.join(format!(
-            "{}.nib",
-            self.plist["NSMainNibFile"].as_string().unwrap(),
-        ))
+        if self.plist.contains_key("NSMainNibFile") {
+            Some(self.path.join(format!(
+                "{}.nib",
+                self.plist["NSMainNibFile"].as_string().unwrap(),
+            )))
+        } else {
+            None
+        }
     }
 }

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -77,7 +77,17 @@ impl Bundle {
 
     pub fn icon_path(&self) -> GuestPathBuf {
         if let Some(filename) = self.plist.get("CFBundleIconFile") {
-            self.path.join(filename.as_string().unwrap())
+            if filename
+                .as_string()
+                .unwrap()
+                .to_lowercase()
+                .ends_with(".png")
+            {
+                self.path.join(filename.as_string().unwrap())
+            } else {
+                let filename_with_extension = format!("{}.png", filename.as_string().unwrap());
+                self.path.join(filename_with_extension)
+            }
         } else {
             self.path.join("Icon.png")
         }

--- a/src/frameworks/uikit/ui_nib.rs
+++ b/src/frameworks/uikit/ui_nib.rs
@@ -170,8 +170,15 @@ pub const CLASSES: ClassExports = objc_classes! {
 /// return [nib instantiateWithOwner:[UIApplication sharedApplication]
 ///                     optionsOrNil:nil];
 /// ```
-pub fn load_main_nib_file(env: &mut Environment, _ui_application: id) {
-    let path = env.bundle.main_nib_file_path();
+/// Returns true if the main nib file was loaded, false if not.
+pub fn load_main_nib_file(env: &mut Environment, _ui_application: id) -> bool {
+    let path = match env.bundle.main_nib_file_path() {
+        Some(path) => path,
+        None => {
+            // The application doesn't have a main nib file.
+            return false;
+        }
+    };
 
     let data = env.fs.read(path).unwrap();
 
@@ -198,4 +205,6 @@ pub fn load_main_nib_file(env: &mut Environment, _ui_application: id) {
     }
 
     release(env, unarchiver);
+
+    return true;
 }

--- a/src/frameworks/uikit/ui_view.rs
+++ b/src/frameworks/uikit/ui_view.rs
@@ -67,7 +67,26 @@ pub const CLASSES: ClassExports = objc_classes! {
     env.objc.get_known_class("CALayer", &mut env.mem)
 }
 
-// TODO: initWithFrame:, accessors, etc
+- (id)initWithFrame:(CGRect)frame { // CGRect
+    let host_object: &mut UIViewHostObject = env.objc.borrow_mut(this);
+    host_object.bounds = frame;
+    host_object.center = CGPoint { x: frame.size.width / 2.0, y: frame.size.height / 2.0 };
+
+    log_dbg!(
+        "[(UIView*){:?} initWithFrame:{:?}]",
+        this,
+        frame,
+    );
+
+    let layer = host_object.layer;
+    () = msg![env; layer setDelegate:this];
+
+    env.framework_state.uikit.ui_view.views.push(this);
+
+    this
+}
+
+// TODO: accessors
 
 // NSCoding implementation
 - (id)initWithCoder:(id)coder {
@@ -107,6 +126,12 @@ pub const CLASSES: ClassExports = objc_classes! {
 // TODO: setMultipleTouchEnabled
 - (())setMultipleTouchEnabled:(bool)_enabled {
     // TODO: enable multitouch
+}
+
+- (())addSubview:(id)view { // UIView *
+    () = msg![env; view layoutSubviews];
+    // TODO: keep a list of subviews somewhere
+    () = msg![env; this layoutSubviews];
 }
 
 - (())layoutSubviews {

--- a/src/frameworks/uikit/ui_window.rs
+++ b/src/frameworks/uikit/ui_window.rs
@@ -15,6 +15,10 @@ pub const CLASSES: ClassExports = objc_classes! {
 
 // TODO
 
+- (())makeKeyAndVisible {
+  // TODO: implement support for hidden/non-key UIWindow objects
+}
+
 @end
 
 };

--- a/src/libc/stdlib.rs
+++ b/src/libc/stdlib.rs
@@ -182,6 +182,13 @@ fn setenv(env: &mut Environment, name: ConstPtr<u8>, value: ConstPtr<u8>, overwr
     0 // success
 }
 
+// Apple explicitly says to not call the exit() function. Some apps do it anyway.
+// See https://developer.apple.com/library/archive/qa/qa1561/_index.html
+fn exit(_env: &mut Environment, code: i32) {
+    println!("Application exited with code {}.", code);
+    std::process::exit(code);
+}
+
 pub const FUNCTIONS: FunctionExports = &[
     export_c_func!(malloc(_)),
     export_c_func!(calloc(_, _)),
@@ -195,4 +202,5 @@ pub const FUNCTIONS: FunctionExports = &[
     export_c_func!(random()),
     export_c_func!(getenv(_)),
     export_c_func!(setenv(_, _, _)),
+    export_c_func!(exit(_)),
 ];


### PR DESCRIPTION
Some apps don't have main nib files and instead choose to do their view initialization and layout in code (probably because nibs, xibs, and storyboards don't really play nice with source control). This additionally means that they have to provide their app delegate class name to UIApplicationMain(). This PR adds basic support for those apps, supporting only scenarios like this one:

```objc
- (void)applicationDidFinishLaunching:(UIApplication *)application {
    window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
    glView = [[EAGLView alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
    [window addSubview:glView];
    [window makeKeyAndVisible];
    [glView startAnimation];
}
```

In addition, this PR fixes some cases of the "Could not read icon file" issue. Some apps don't include the extension of their icon file in their Info.plist, so we add ".png" to the end if there is no extension provided. A logical extension of this would be to look for images suffixed with `@2x` (e.g. `Icon@2x.png`) once Retina mode is supported.

Finally, this PR implements exit().