### PR TITLE
Implement more UIDevice calls

### DIFF
--- a/src/frameworks/uikit/ui_device.rs
+++ b/src/frameworks/uikit/ui_device.rs
@@ -60,8 +60,8 @@ pub const CLASSES: ClassExports = objc_classes! {
     ns_string::get_static_str(env, "UIUserInterfaceIdiom.phone")
 }
 
-- (id)systemName {
-    ns_string::get_static_str(env, "iPhoneOS")
+- (id)name {
+    ns_string::get_static_str(env, "touchHLE")
 }
 
 

--- a/src/frameworks/uikit/ui_device.rs
+++ b/src/frameworks/uikit/ui_device.rs
@@ -47,17 +47,24 @@ pub const CLASSES: ClassExports = objc_classes! {
     }
 }
 
-- (())beginGeneratingDeviceOrientationNotifications {
-    log!("TODO: beginGeneratingDeviceOrientationNotifications");
-}
-- (())endGeneratingDeviceOrientationNotifications {
-    log!("TODO: endGeneratingDeviceOrientationNotifications");
-}
-
 // NSString
 - (id)systemVersion {
     ns_string::get_static_str(env, "2.0")
 }
+
+- (id)systemName {
+    ns_string::get_static_str(env, "iPhoneOS")
+}
+
+- (id)UI_USER_INTERFACE_IDIOM {
+    ns_string::get_static_str(env, "UIUserInterfaceIdiom.phone")
+}
+
+- (id)systemName {
+    ns_string::get_static_str(env, "iPhoneOS")
+}
+
+
 
 - (bool)isMultitaskingSupported {
     false

--- a/src/frameworks/uikit/ui_device.rs
+++ b/src/frameworks/uikit/ui_device.rs
@@ -56,10 +56,6 @@ pub const CLASSES: ClassExports = objc_classes! {
     ns_string::get_static_str(env, "iPhoneOS")
 }
 
-- (id)UI_USER_INTERFACE_IDIOM {
-    ns_string::get_static_str(env, "UIUserInterfaceIdiom.phone")
-}
-
 - (id)name {
     ns_string::get_static_str(env, "touchHLE")
 }


### PR DESCRIPTION
Suggestions/TODO: 
1. Make most or every field customizable via flags (like the version)
2. Implement all Battery related functions, redirecting them from the host machine. 
3. Rename the device name to the host machine’s user set name or computer model name?