### PR TITLE
Implement dynamic linking & Fix Linux building

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -10,7 +10,7 @@ There is one special external dependency, Boost:
 * On other OSes, install Boost from your package manager. If you are on macOS and using [Homebrew](https://brew.sh/): `brew install boost`.
 
 Then you just need to run `cargo run --release` (for a release build) or `cargo run` (for a debug build) to build and run touchHLE. On an underpowered, passively-cooled, 2-core laptop (2017 Retina MacBook), a clean release build takes a bit less than 9 minutes.
-* To compile with dynamically linked libraries, append `--features dynamic` to the end of the cargo build command.
+* To compile with dynamically linked libraries, append `--no-default-features --features dynamic` to the end of the cargo build command.
 
 The `touchHLE_dylibs` and `touchHLE_fonts` directories contain files that the resulting binary will need at runtime, so you'll need to copy them if you want to distribute the result. You also should include the license files.
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -10,7 +10,8 @@ There is one special external dependency, Boost:
 * On other OSes, install Boost from your package manager. If you are on macOS and using [Homebrew](https://brew.sh/): `brew install boost`.
 
 Then you just need to run `cargo run --release` (for a release build) or `cargo run` (for a debug build) to build and run touchHLE. On an underpowered, passively-cooled, 2-core laptop (2017 Retina MacBook), a clean release build takes a bit less than 9 minutes.
-* To compile with dynamically linked libraries, append `--no-default-features` to the end of the cargo build command.
+
+touchHLE can also be dynamically linked (which means instead of using the bundled dependencies, it will use the dependencies provided by your system). To build a dynamically linked version of touchHLE, you will need to have the SDL2 and OpenAL shared libraries installed, and then you can append `--no-default-features` (this flag is passed in to disable static linking, which is the default) to the end of the cargo build command.
 
 The `touchHLE_dylibs` and `touchHLE_fonts` directories contain files that the resulting binary will need at runtime, so you'll need to copy them if you want to distribute the result. You also should include the license files.
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -10,7 +10,7 @@ There is one special external dependency, Boost:
 * On other OSes, install Boost from your package manager. If you are on macOS and using [Homebrew](https://brew.sh/): `brew install boost`.
 
 Then you just need to run `cargo run --release` (for a release build) or `cargo run` (for a debug build) to build and run touchHLE. On an underpowered, passively-cooled, 2-core laptop (2017 Retina MacBook), a clean release build takes a bit less than 9 minutes.
-* To compile with dynamically linked libraries, append `--no-default-features --features dynamic` to the end of the cargo build command.
+* To compile with dynamically linked libraries, append `--no-default-features` to the end of the cargo build command.
 
 The `touchHLE_dylibs` and `touchHLE_fonts` directories contain files that the resulting binary will need at runtime, so you'll need to copy them if you want to distribute the result. You also should include the license files.
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -10,6 +10,7 @@ There is one special external dependency, Boost:
 * On other OSes, install Boost from your package manager. If you are on macOS and using [Homebrew](https://brew.sh/): `brew install boost`.
 
 Then you just need to run `cargo run --release` (for a release build) or `cargo run` (for a debug build) to build and run touchHLE. On an underpowered, passively-cooled, 2-core laptop (2017 Retina MacBook), a clean release build takes a bit less than 9 minutes.
+* To compile with dynamically linked libraries, append `--features dynamic` to the end of the cargo build command.
 
 The `touchHLE_dylibs` and `touchHLE_fonts` directories contain files that the resulting binary will need at runtime, so you'll need to copy them if you want to distribute the result. You also should include the license files.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
 name = "plist"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,6 +513,7 @@ dependencies = [
  "cfg-if",
  "cmake",
  "libc",
+ "pkg-config",
  "version-compare",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,8 @@ authors = { workspace = true }
 homepage = { workspace = true }
 
 [features]
-# Static linking is default.
 default = ["static"]
-dynamic = ["sdl2/use-pkgconfig"]
-static = ["sdl2/bundled", "sdl2/static-link"]
+static = ["sdl2/bundled", "sdl2/static-link", "touchHLE_openal_soft_wrapper/static", "touchHLE_dynarmic_wrapper/static"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -42,7 +40,7 @@ rusttype = "0.9.3"
 # which is old enough that its bundled SDL2 version is missing various nice
 # things, and doesn't build on macOS.
 # This is a temporary fork to get a newer SDL2 version.
-sdl2 = { git = "https://github.com/hikari-no-yume/rust-sdl2.git", branch = "update-bundled-SDL2" }
+sdl2 = { git = "https://github.com/hikari-no-yume/rust-sdl2.git", branch = "update-bundled-SDL2", features = ["use-pkgconfig"] }
 touchHLE_dr_mp3_wrapper = { path = "src/audio/dr_mp3_wrapper" }
 touchHLE_dynarmic_wrapper = { path = "src/cpu/dynarmic_wrapper" }
 touchHLE_gl_bindings = { path = "src/window/gl_bindings" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,9 @@ homepage = { workspace = true }
 
 [features]
 # Static linking is default.
-dynamic = []
+default = ["static"]
+dynamic = ["sdl2/use-pkgconfig"]
+static = ["sdl2/bundled", "sdl2/static-link"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -40,7 +42,7 @@ rusttype = "0.9.3"
 # which is old enough that its bundled SDL2 version is missing various nice
 # things, and doesn't build on macOS.
 # This is a temporary fork to get a newer SDL2 version.
-sdl2 = { git = "https://github.com/hikari-no-yume/rust-sdl2.git", branch = "update-bundled-SDL2", features = ["bundled", "static-link"] }
+sdl2 = { git = "https://github.com/hikari-no-yume/rust-sdl2.git", branch = "update-bundled-SDL2" }
 touchHLE_dr_mp3_wrapper = { path = "src/audio/dr_mp3_wrapper" }
 touchHLE_dynarmic_wrapper = { path = "src/cpu/dynarmic_wrapper" }
 touchHLE_gl_bindings = { path = "src/window/gl_bindings" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ license = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }
 
+[features]
+# Static linking is default.
+dynamic = []
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ homepage = { workspace = true }
 
 [features]
 default = ["static"]
-static = ["sdl2/bundled", "sdl2/static-link", "touchHLE_openal_soft_wrapper/static", "touchHLE_dynarmic_wrapper/static"]
+static = ["sdl2/bundled", "sdl2/static-link", "touchHLE_openal_soft_wrapper/static"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/audio/openal_soft_wrapper/Cargo.toml
+++ b/src/audio/openal_soft_wrapper/Cargo.toml
@@ -14,3 +14,6 @@ path = "lib.rs"
 
 [build-dependencies]
 cmake = { workspace = true }
+
+[features]
+static = []

--- a/src/audio/openal_soft_wrapper/build.rs
+++ b/src/audio/openal_soft_wrapper/build.rs
@@ -12,11 +12,10 @@ fn link_search(path: &Path) {
     println!("cargo:rustc-link-search=native={}", path.to_str().unwrap());
 }
 fn link_lib(lib: &str) {
-    // Default to static linking
-    if cfg!(feature = "dynamic") {
-        println!("cargo:rustc-link-lib=dylib={}", lib);
-    } else {
+    if cfg!(feature = "static") {
         println!("cargo:rustc-link-lib=static={}", lib);
+    } else {
+        println!("cargo:rustc-link-lib=dylib={}", lib);
     }
 }
 
@@ -25,7 +24,7 @@ fn link_framework(framework: &str) {
 }
 
 fn main() {
-    if !cfg!(feature = "dynamic") {
+    if cfg!(feature = "static") {
         let package_root = Path::new(env!("CARGO_MANIFEST_DIR"));
         let workspace_root = package_root.join("../../..");
 
@@ -36,24 +35,25 @@ fn main() {
         link_search(&openal_soft_out.join("lib"));
         // some Linux systems
         link_search(&openal_soft_out.join("lib64"));
+
+        if cfg!(target_os = "linux") {
+            // OpenAL on Linux depends on sndio, needs to be dynamically linked
+            println!("cargo:rustc-link-lib=dylib=sndio");
+        }
+        // Some dependencies of OpenAL Soft.
+        if cfg!(target_os = "macos") {
+            link_framework("AudioToolbox");
+            link_framework("CoreAudio");
+            link_framework("CoreFoundation");
+        }
     }
-    // Some dependencies of OpenAL Soft.
-    if cfg!(target_os = "macos") {
-        link_framework("AudioToolbox");
-        link_framework("CoreAudio");
-        link_framework("CoreFoundation");
-    }
+
     // see also src/audio/openal.rs
     link_lib(if cfg!(target_os = "windows") {
         "OpenAL32"
     } else {
         "openal"
     });
-
-    if cfg!(target_os = "linux") {
-        // OpenAL on Linux depends on sndio, needs to be dynamically linked
-        println!("cargo:rustc-link-lib=dylib=sndio");
-    }
     // rerun-if-changed seems to not work if pointed to a directory :(
     //rerun_if_changed(&workspace_root.join("vendor/openal-soft"));
 }

--- a/src/cpu/dynarmic_wrapper/Cargo.toml
+++ b/src/cpu/dynarmic_wrapper/Cargo.toml
@@ -15,3 +15,6 @@ path = "lib.rs"
 [build-dependencies]
 cc = { workspace = true }
 cmake = { workspace = true }
+
+[features]
+static = []

--- a/src/cpu/dynarmic_wrapper/Cargo.toml
+++ b/src/cpu/dynarmic_wrapper/Cargo.toml
@@ -17,4 +17,3 @@ cc = { workspace = true }
 cmake = { workspace = true }
 
 [features]
-static = []

--- a/src/cpu/dynarmic_wrapper/build.rs
+++ b/src/cpu/dynarmic_wrapper/build.rs
@@ -12,11 +12,10 @@ fn link_search(path: &Path) {
     println!("cargo:rustc-link-search=native={}", path.to_str().unwrap());
 }
 fn link_lib(lib: &str) {
-    // Default to static linking
-    if cfg!(feature = "dynamic") {
-        println!("cargo:rustc-link-lib=dylib={}", lib);
-    } else {
+    if cfg!(feature = "static") {
         println!("cargo:rustc-link-lib=static={}", lib);
+    } else {
+        println!("cargo:rustc-link-lib=dylib={}", lib);
     }
 }
 

--- a/src/cpu/dynarmic_wrapper/build.rs
+++ b/src/cpu/dynarmic_wrapper/build.rs
@@ -12,11 +12,7 @@ fn link_search(path: &Path) {
     println!("cargo:rustc-link-search=native={}", path.to_str().unwrap());
 }
 fn link_lib(lib: &str) {
-    if cfg!(feature = "static") {
-        println!("cargo:rustc-link-lib=static={}", lib);
-    } else {
-        println!("cargo:rustc-link-lib=dylib={}", lib);
-    }
+    println!("cargo:rustc-link-lib=static={}", lib);
 }
 
 // See https://github.com/rust-lang/cc-rs/issues/565

--- a/src/cpu/dynarmic_wrapper/build.rs
+++ b/src/cpu/dynarmic_wrapper/build.rs
@@ -52,6 +52,7 @@ fn main() {
     let mut build = cmake::Config::new(workspace_root.join("vendor/dynarmic"));
     build.define("DYNARMIC_WARNINGS_AS_ERRORS", "OFF");
     build.define("DYNARMIC_TESTS", "OFF");
+    build.define("DYNARMIC_USE_BUNDLED_EXTERNALS", "ON");
     // This is Windows-specific because on macOS or Linux, you can grab
     // Boost with your package manager.
     if cfg!(target_os = "windows") {
@@ -72,16 +73,11 @@ fn main() {
             .join("build/externals/fmt")
             .join(build_type_windows()),
     );
-    // fmtd isn't on Linux
-    if !cfg!(target_os = "linux") {
-        link_lib(if cfg!(debug_assertions) {
-            "fmtd"
-        } else {
-            "fmt"
-        });
+    link_lib(if cfg!(debug_assertions) {
+        "fmtd"
     } else {
-        println!("cargo:rustc-link-lib=dylib=fmt");
-    }
+        "fmt"
+    });
     link_search(
         &dynarmic_out
             .join("build/externals/mcl/src")


### PR DESCRIPTION
This PR implements a dynamic linking compile time feature, which can be enabled with `--features dynamic`, or in the `Cargo.toml`. This PR also fixes building on Linux. Tested on Linux, Windows and MacOS (Big Sur).