### PR TITLE
Add color blending in `cg_bitmap_context`

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -231,7 +231,6 @@ impl Font {
                     continue;
                 };
                 // y needs to be flipped to point up
-                // FIXME: blending
                 let glyph_height = glyph_bounds.height();
                 let x_offset = glyph_bounds.min.x;
                 let y_offset = ((origin.1 + line_y).round() as i32) + glyph_bounds.max.y;


### PR DESCRIPTION
Fixes overlapping letters not displaying correctly - #15.

Should we also blend the alpha channel when `data.alpha_info == kCGImageAlphaOnly`?