### PR TITLE
Add Github Action workflows for MacOS and Windows builds

### DIFF
--- a/.github/workflows/touchHLE_release.yml
+++ b/.github/workflows/touchHLE_release.yml
@@ -1,0 +1,65 @@
+name: Build touchHLE
+
+on:
+  push:
+    branches: [ "trunk" ]
+  pull_request:
+    branches: [ "trunk" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-osx:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get Submodules
+      run: git submodule update --init
+    - name: Install Boost
+      run: brew install boost
+    - name: Build
+      run: cargo build --release && mv target/release/touchHLE .
+    - uses: actions/upload-artifact@v3
+      with:
+        name: touchHLE_macOS_x86_64
+        path: |
+          touchHLE_dylibs/
+          touchHLE_fonts/
+          APP_SUPPORT.md
+          CHANGELOG.md
+          LICENSE
+          README.md
+          touchHLE
+          touchHLE_default_options.txt
+          touchHLE_options.txt
+
+  build-win:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get Submodules
+      run: git submodule update --init
+    - name: Download Boost
+      run: curl -L -o boost_1_81_0.7z "https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.7z"
+    - name: Extract Boost
+      run: 7z -ovendor x boost_1_81_0.7z && ren vendor\boost_1_81_0 boost
+    - name: Build
+      run: cargo build --release && move target/release/touchHLE.exe .
+    - uses: actions/upload-artifact@v3
+      with:
+        name: touchHLE_Windows_x86_64
+        path: |
+          touchHLE_dylibs/
+          touchHLE_fonts/
+          APP_SUPPORT.md
+          CHANGELOG.md
+          LICENSE
+          README.md
+          touchHLE.exe
+          touchHLE_default_options.txt
+          touchHLE_options.txt

--- a/.github/workflows/touchHLE_release.yml
+++ b/.github/workflows/touchHLE_release.yml
@@ -25,16 +25,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: touchHLE_macOS_x86_64
-        path: |
-          touchHLE_dylibs/
-          touchHLE_fonts/
-          APP_SUPPORT.md
-          CHANGELOG.md
-          LICENSE
-          README.md
-          touchHLE
-          touchHLE_default_options.txt
-          touchHLE_options.txt
+        path: touchHLE
 
   build-win:
 
@@ -53,13 +44,4 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: touchHLE_Windows_x86_64
-        path: |
-          touchHLE_dylibs/
-          touchHLE_fonts/
-          APP_SUPPORT.md
-          CHANGELOG.md
-          LICENSE
-          README.md
-          touchHLE.exe
-          touchHLE_default_options.txt
-          touchHLE_options.txt
+        path: touchHLE.exe


### PR DESCRIPTION
This adds two Github Action jobs which build touchHLE and upload the results as an artifact. The uploaded artifact can be un-zipped and run just like a regular release, as I've included the `touchHLE_dylibs` and `touchHLE_fonts` directories.