### PR TITLE
Add runtime type checking for host-to-host messages in debug builds

### DIFF
--- a/src/frameworks/foundation.rs
+++ b/src/frameworks/foundation.rs
@@ -55,7 +55,7 @@ pub struct State {
 pub type NSInteger = i32;
 pub type NSUInteger = u32;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[repr(C, packed)]
 pub struct NSRange {
     pub location: NSUInteger,

--- a/src/frameworks/foundation/ns_dictionary.rs
+++ b/src/frameworks/foundation/ns_dictionary.rs
@@ -9,8 +9,8 @@ use super::ns_property_list_serialization::deserialize_plist_from_file;
 use super::{ns_string, ns_url, NSUInteger};
 use crate::fs::GuestPath;
 use crate::objc::{
-    autorelease, id, msg, msg_class, nil, objc_classes, release, retain, ClassExports, HostObject,
-    NSZonePtr,
+    autorelease, id, msg, msg_class, msg_unchecked, nil, objc_classes, release, retain,
+    ClassExports, HostObject, NSZonePtr,
 };
 use crate::Environment;
 use std::collections::HashMap;
@@ -112,7 +112,7 @@ pub const CLASSES: ClassExports = objc_classes! {
     // This passes on the va_args by creative abuse of untyped function calls.
     // I should be ashamed, and you should be careful.
     let new_dict: id = msg![env; this alloc];
-    let new_dict: id = msg![env; new_dict initWithObjectsAndKeys:first_object];
+    let new_dict: id = msg_unchecked![env; new_dict initWithObjectsAndKeys:first_object];
     autorelease(env, new_dict)
 }
 

--- a/src/frameworks/foundation/ns_timer.rs
+++ b/src/frameworks/foundation/ns_timer.rs
@@ -79,7 +79,7 @@ pub const CLASSES: ClassExports = objc_classes! {
                             selector:(SEL)selector
                             userInfo:(id)user_info
                              repeats:(bool)repeats {
-    let timer = msg![env; this timerWithTimeInterval:interval
+    let timer: id = msg![env; this timerWithTimeInterval:interval
                                               target:target
                                             selector:selector
                                             userInfo:user_info

--- a/src/frameworks/uikit/ui_view.rs
+++ b/src/frameworks/uikit/ui_view.rs
@@ -330,7 +330,7 @@ pub const CLASSES: ClassExports = objc_classes! {
     let layer = env.objc.borrow::<UIViewHostObject>(this).layer;
     msg![env; layer position]
 }
-- (())setCenter:(CGRect)center {
+- (())setCenter:(CGPoint)center {
     let layer = env.objc.borrow::<UIViewHostObject>(this).layer;
     msg![env; layer setPosition:center]
 }

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -91,6 +91,10 @@ impl<T, const MUT: bool> Ptr<T, MUT> {
     pub fn is_null(self) -> bool {
         self.to_bits() == 0
     }
+
+    pub fn cast_void(self) -> Ptr<std::ffi::c_void, MUT> {
+        self.cast::<std::ffi::c_void>()
+    }
 }
 
 impl<T> ConstPtr<T> {

--- a/src/objc.rs
+++ b/src/objc.rs
@@ -32,7 +32,9 @@ mod synchronization;
 
 pub use classes::{objc_classes, Class, ClassExports, ClassTemplate};
 pub use messages::{
-    autorelease, msg, msg_class, msg_send, msg_send_super2, msg_super, objc_super, release, retain,
+    autorelease, generate_type_id, msg, msg_class, msg_class_unchecked, msg_send, msg_send_debug,
+    msg_send_super2, msg_send_super2_debug, msg_super, msg_unchecked, objc_debug, objc_super,
+    objc_super_debug, release, retain,
 };
 pub use methods::{GuestIMP, HostIMP, IMP};
 pub use objects::{


### PR DESCRIPTION
Partially fixes #140. 

It should be doable to check host to guest calls as well, but that would involve parsing the type string and I didn't really feel like doing that now :P. Some of the weird looking commits are to make the `msg!` calls work again, and I also took the liberty of macro-ifying the HostIMP calls. 

