### PR TITLE
Multi-touch

### DIFF
--- a/src/frameworks/uikit/ui_event.rs
+++ b/src/frameworks/uikit/ui_event.rs
@@ -6,18 +6,16 @@
 //! `UIEvent`.
 
 use super::ui_touch::UITouchHostObject;
-use crate::frameworks::core_graphics::CGPoint;
+use crate::frameworks::foundation::NSUInteger;
+use crate::mem::MutVoidPtr;
 use crate::objc::{
-    autorelease, id, msg, msg_class, nil, objc_classes, release, retain, ClassExports, HostObject,
-    NSZonePtr,
+    id, msg, msg_class, nil, objc_classes, release, retain, ClassExports, HostObject, NSZonePtr,
 };
 use crate::Environment;
 
 pub(super) struct UIEventHostObject {
     /// `NSSet<UITouch*>*`
     touches: id,
-    /// `UIView*`
-    pub(super) view: id,
 }
 impl HostObject for UIEventHostObject {}
 
@@ -30,34 +28,38 @@ pub const CLASSES: ClassExports = objc_classes! {
 + (id)allocWithZone:(NSZonePtr)_zone {
     let host_object = Box::new(UIEventHostObject {
         touches: nil,
-        view: nil,
     });
     env.objc.alloc_object(this, host_object, &mut env.mem)
 }
 
 - (())dealloc {
-    let &UIEventHostObject { touches, view } = env.objc.borrow(this);
+    let &UIEventHostObject { touches } = env.objc.borrow(this);
     release(env, touches);
-    release(env, view);
 }
 
-- (id)touchesForView:(id)view {
-    let &UIEventHostObject { touches, .. } = env.objc.borrow(this);
-    // TODO: broken for multi-touch
-    let touch: id = msg![env; touches anyObject];
-    let &UITouchHostObject { original_location, window, .. } = env.objc.borrow(touch);
-    // FIXME: handle non-zero-origin windows
-    let location_in_view: CGPoint = msg![env; window convertPoint:original_location toView:view];
-    if msg![env; view pointInside:location_in_view withEvent:this] {
-        msg_class![env; NSSet setWithObject:touch]
-    } else {
-        let empty_set: id = msg_class![env; NSSet new];
-        autorelease(env, empty_set)
+- (id)touchesForView:(id)view_ {
+    let &UIEventHostObject { touches } = env.objc.borrow(this);
+
+    let touches_for_view: id = msg_class![env; NSMutableSet allocWithZone:(MutVoidPtr::null())];
+
+    let touches_arr: id = msg![env; touches allObjects];
+    let touches_count: NSUInteger = msg![env; touches_arr count];
+    for i in 0..touches_count {
+        let touch: id = msg![env; touches_arr objectAtIndex:i];
+        let &UITouchHostObject { view, .. } = env.objc.borrow(touch);
+        if view_ == view {
+            let _: () = msg![env; touches_for_view addObject:touch];
+            if !msg![env; view isMultipleTouchEnabled] {
+                break;
+            }
+        }
     }
+
+    touches_for_view
 }
 
 - (id)allTouches {
-    let &UIEventHostObject { touches, .. } = env.objc.borrow(this);
+    let &UIEventHostObject { touches } = env.objc.borrow(this);
     touches
 }
 
@@ -68,13 +70,10 @@ pub const CLASSES: ClassExports = objc_classes! {
 };
 
 /// For use by [super::ui_touch]: create a `UIEvent` with a set of `UITouch*`
-/// and the view it was originally sent to.
-pub(super) fn new_event(env: &mut Environment, touches: id, view: id) -> id {
+pub(super) fn new_event(env: &mut Environment, touches: id) -> id {
     let event: id = msg_class![env; UIEvent alloc];
     retain(env, touches);
-    retain(env, view);
     let borrow = env.objc.borrow_mut::<UIEventHostObject>(event);
     borrow.touches = touches;
-    borrow.view = view;
     event
 }

--- a/src/frameworks/uikit/ui_touch.rs
+++ b/src/frameworks/uikit/ui_touch.rs
@@ -112,7 +112,10 @@ pub fn handle_event(env: &mut Environment, event: Event) {
     match event {
         Event::TouchesDown(map) => {
             let finger_id = 0;
-            assert!(map.len() == 1 && map.contains_key(&finger_id));
+            if !map.contains_key(&finger_id) {
+                log!("TODO: TouchesDown handle other fingers");
+                return;
+            }
             let coords = map.get(&finger_id).unwrap();
 
             if env
@@ -229,7 +232,10 @@ pub fn handle_event(env: &mut Environment, event: Event) {
         }
         Event::TouchesMove(map) => {
             let finger_id = 0;
-            assert!(map.len() == 1 && map.contains_key(&finger_id));
+            if !map.contains_key(&finger_id) {
+                log!("TODO: TouchesMove handle other fingers");
+                return;
+            }
             let coords = map.get(&finger_id).unwrap();
 
             let Some(&touch) = env
@@ -277,7 +283,10 @@ pub fn handle_event(env: &mut Environment, event: Event) {
         }
         Event::TouchesUp(map) => {
             let finger_id = 0;
-            assert!(map.len() == 1 && map.contains_key(&finger_id));
+            if !map.contains_key(&finger_id) {
+                log!("TODO: TouchesUp handle other fingers");
+                return;
+            }
             let coords = map.get(&finger_id).unwrap();
 
             let Some(&touch) = env

--- a/src/frameworks/uikit/ui_touch.rs
+++ b/src/frameworks/uikit/ui_touch.rs
@@ -158,7 +158,7 @@ fn handle_touches_down(env: &mut Environment, map: HashMap<FingerId, Coords>) {
             return handle_touches_move(env, HashMap::from([(finger_id, coords)]));
         }
 
-        log_dbg!("Finger {} touch down: {:?}", finger_id, coords);
+        log_dbg!("Finger {:?} touch down: {:?}", finger_id, coords);
 
         let location = CGPoint {
             x: coords.0,
@@ -274,13 +274,13 @@ fn handle_touches_move(env: &mut Environment, map: HashMap<FingerId, Coords>) {
             .get(&finger_id)
         else {
             log!(
-                "Warning: Finger {} touch move event received but no current touch, ignoring.",
+                "Warning: Finger {:?} touch move event received but no current touch, ignoring.",
                 finger_id
             );
             continue;
         };
 
-        log_dbg!("Finger {} touch move: {:?}", finger_id, coords);
+        log_dbg!("Finger {:?} touch move: {:?}", finger_id, coords);
 
         let location = CGPoint {
             x: coords.0,
@@ -340,13 +340,13 @@ fn handle_touches_up(env: &mut Environment, map: HashMap<FingerId, Coords>) {
             .get(&finger_id)
         else {
             log!(
-                "Warning: Finger {} touch up event received but no current touch, ignoring.",
+                "Warning: Finger {:?} touch up event received but no current touch, ignoring.",
                 finger_id
             );
             continue;
         };
 
-        log_dbg!("Finger {} touch up: {:?}", finger_id, coords);
+        log_dbg!("Finger {:?} touch up: {:?}", finger_id, coords);
 
         let location = CGPoint {
             x: coords.0,

--- a/src/frameworks/uikit/ui_touch.rs
+++ b/src/frameworks/uikit/ui_touch.rs
@@ -6,20 +6,21 @@
 //! `UITouch`.
 
 use super::ui_event;
-use super::ui_event::UIEventHostObject;
 use crate::frameworks::core_graphics::{CGPoint, CGRect};
 use crate::frameworks::foundation::{NSInteger, NSTimeInterval, NSUInteger};
+use crate::mem::MutVoidPtr;
 use crate::objc::{
     autorelease, id, msg, msg_class, nil, objc_classes, release, retain, ClassExports, HostObject,
     NSZonePtr,
 };
 use crate::window::{Coords, Event, FingerId};
 use crate::Environment;
-use std::collections::HashMap;
+use std::collections::hash_map::{Entry, HashMap};
 
 pub type UITouchPhase = NSInteger;
 pub const UITouchPhaseBegan: UITouchPhase = 0;
 pub const UITouchPhaseMoved: UITouchPhase = 1;
+pub const UITouchPhaseStationary: UITouchPhase = 2;
 pub const UITouchPhaseEnded: UITouchPhase = 3;
 
 #[derive(Default)]
@@ -29,7 +30,7 @@ pub struct State {
 
 pub(super) struct UITouchHostObject {
     /// Strong reference to the `UIView`
-    view: id,
+    pub(super) view: id,
     /// Strong reference to the `UIWindow`, used as a reference for co-ordinate
     /// space conversion
     pub(super) window: id,
@@ -37,8 +38,6 @@ pub(super) struct UITouchHostObject {
     location: CGPoint,
     /// Relative to the screen
     previous_location: CGPoint,
-    /// Relative to the screen, used for `touchesForView:`
-    pub(super) original_location: CGPoint,
     timestamp: NSTimeInterval,
     phase: UITouchPhase,
 }
@@ -56,7 +55,6 @@ pub const CLASSES: ClassExports = objc_classes! {
         window: nil,
         location: CGPoint { x: 0.0, y: 0.0 },
         previous_location: CGPoint { x: 0.0, y: 0.0 },
-        original_location: CGPoint { x: 0.0, y: 0.0 },
         timestamp: 0.0,
         phase: UITouchPhaseBegan,
     });
@@ -109,6 +107,11 @@ pub const CLASSES: ClassExports = objc_classes! {
 
 /// [super::handle_events] will forward touch events to this function.
 pub fn handle_event(env: &mut Environment, event: Event) {
+    // before processing anything, we mark all current touches as stationary
+    let current_touches = &env.framework_state.uikit.ui_touch.current_touches;
+    for &touch in (*current_touches).values() {
+        env.objc.borrow_mut::<UITouchHostObject>(touch).phase = UITouchPhaseStationary;
+    }
     match event {
         Event::TouchesDown(map) => handle_touches_down(env, map),
         Event::TouchesMove(map) => handle_touches_move(env, map),
@@ -118,31 +121,18 @@ pub fn handle_event(env: &mut Environment, event: Event) {
 }
 
 fn handle_touches_down(env: &mut Environment, map: HashMap<FingerId, Coords>) {
-    let finger_id = 0;
-    if !map.contains_key(&finger_id) {
-        log!("TODO: TouchesDown handle other fingers");
-        return;
-    }
-    let coords = map.get(&finger_id).unwrap();
-
-    if env
+    // Assumes the last window in the list is the one on top.
+    // TODO: this is not correct once we support zPosition.
+    let Some(&top_window) = env
         .framework_state
         .uikit
-        .ui_touch
-        .current_touches
-        .contains_key(&finger_id)
-    {
-        log!(
-            "Warning: New touch initiated but current touch did not end yet, treating as movement."
-        );
-        return handle_event(env, Event::TouchesMove(map));
-    }
-
-    log_dbg!("Touch down: {:?}", coords);
-
-    let location = CGPoint {
-        x: coords.0,
-        y: coords.1,
+        .ui_view
+        .ui_window
+        .visible_windows
+        .last()
+    else {
+        log!("No visible window, touch events ignored");
+        return;
     };
 
     // UIKit creates and drains autorelease pools when handling events.
@@ -154,199 +144,253 @@ fn handle_touches_down(env: &mut Environment, map: HashMap<FingerId, Coords>) {
     // event was dispatched. Maybe we'll need to fix this eventually.
     let timestamp: NSTimeInterval = msg_class![env; NSProcessInfo systemUptime];
 
-    // TODO: is this the correct state of the UITouch and UIEvent during
-    //       hit testing?
+    let touches: id = msg_class![env; NSMutableSet allocWithZone:(MutVoidPtr::null())];
 
-    let new_touch: id = msg_class![env; UITouch alloc];
-    *env.objc.borrow_mut(new_touch) = UITouchHostObject {
-        view: nil,
-        window: nil,
-        location,
-        previous_location: location,
-        original_location: location,
-        timestamp,
-        phase: UITouchPhaseBegan,
-    };
-    autorelease(env, new_touch);
+    for (finger_id, coords) in map {
+        let current_touches = &mut env.framework_state.uikit.ui_touch.current_touches;
 
-    let touches: id = msg_class![env; NSSet setWithObject:new_touch];
-    let event = ui_event::new_event(env, touches, nil);
+        if current_touches.contains_key(&finger_id) {
+            // this seems to happen only on the desktop with a single touch
+            assert_eq!(current_touches.len(), 1);
+            log!(
+                "Warning: New touch initiated but current touch did not end yet, treating as movement."
+            );
+            return handle_touches_move(env, HashMap::from([(finger_id, coords)]));
+        }
+
+        log_dbg!("Finger {} touch down: {:?}", finger_id, coords);
+
+        let location = CGPoint {
+            x: coords.0,
+            y: coords.1,
+        };
+
+        // TODO: is this the correct state of the UITouch and UIEvent during
+        //       hit testing?
+
+        let new_touch: id = msg_class![env; UITouch alloc];
+        *env.objc.borrow_mut(new_touch) = UITouchHostObject {
+            view: nil,
+            window: nil,
+            location,
+            previous_location: location,
+            timestamp,
+            phase: UITouchPhaseBegan,
+        };
+        autorelease(env, new_touch);
+
+        let _: () = msg![env; touches addObject:new_touch];
+
+        let _ = &env
+            .framework_state
+            .uikit
+            .ui_touch
+            .current_touches
+            .insert(finger_id, new_touch);
+        retain(env, new_touch);
+    }
+
+    let event = ui_event::new_event(env, touches);
     autorelease(env, event);
 
-    // FIXME: handle non-fullscreen windows in hit testing and
-    //        co-ordinate space translation.
+    // view to set of touches for this view
+    let mut view_touches: HashMap<id, id> = HashMap::new();
 
-    // Assumes the last window in the list is the one on top.
-    // TODO: this is not correct once we support zPosition.
-    let Some(&top_window) = env
-        .framework_state
-        .uikit
-        .ui_view
-        .ui_window
-        .visible_windows
-        .last()
-    else {
-        log!("No visible window, touch event ignored");
-        return;
-    };
+    let touches_arr: id = msg![env; touches allObjects];
+    let touches_count: NSUInteger = msg![env; touches_arr count];
+    for i in 0..touches_count {
+        let touch: id = msg![env; touches_arr objectAtIndex:i];
+        let &UITouchHostObject { location, .. } = env.objc.borrow(touch);
 
-    let view: id = msg![env; top_window hitTest:location withEvent:event];
-    if view == nil {
-        log!(
-            "Couldn't find a view for touch at {:?} in window {:?}, discarding",
-            location,
-            top_window,
-        );
-        return;
-    } else {
+        // FIXME: handle non-fullscreen windows in hit testing and
+        //        co-ordinate space translation.
+
+        let view: id = msg![env; top_window hitTest:location withEvent:event];
+        if view == nil {
+            log!(
+                "Couldn't find a view for touch at {:?} in window {:?}, discarding",
+                location,
+                top_window,
+            );
+            continue;
+        } else {
+            log_dbg!(
+                "Found view {:?} with frame {:?} for touch at {:?} in window {:?}",
+                view,
+                {
+                    let f: CGRect = msg![env; view frame];
+                    f
+                },
+                location,
+                top_window,
+            );
+        }
+
+        if let Entry::Vacant(e) = view_touches.entry(view) {
+            let touches: id = msg_class![env; NSMutableSet allocWithZone:(MutVoidPtr::null())];
+            e.insert(touches);
+        }
+        let touches: id = *view_touches.get(&view).unwrap();
+        let _: () = msg![env; touches addObject:touch];
+
+        retain(env, view);
+        retain(env, top_window);
+        {
+            let new_touch = env.objc.borrow_mut::<UITouchHostObject>(touch);
+            new_touch.view = view;
+            new_touch.window = top_window;
+        }
+    }
+
+    for (view, touches) in view_touches {
         log_dbg!(
-            "Found view {:?} with frame {:?} for touch at {:?} in window {:?}",
+            "Sending [{:?} touchesBegan:{:?} withEvent:{:?}]",
             view,
-            {
-                let f: CGRect = msg![env; view frame];
-                f
-            },
-            location,
-            top_window,
+            touches,
+            event
         );
+        let _: () = msg![env; view touchesBegan:touches withEvent:event];
     }
-
-    retain(env, view);
-    retain(env, top_window);
-    {
-        let new_touch = env.objc.borrow_mut::<UITouchHostObject>(new_touch);
-        new_touch.view = view;
-        new_touch.window = top_window;
-    }
-
-    retain(env, view);
-    env.objc.borrow_mut::<UIEventHostObject>(event).view = view;
-
-    env.framework_state
-        .uikit
-        .ui_touch
-        .current_touches
-        .insert(finger_id, new_touch);
-    retain(env, new_touch);
-
-    log_dbg!(
-        "Sending [{:?} touchesBegan:{:?} withEvent:{:?}]",
-        view,
-        touches,
-        event
-    );
-    let _: () = msg![env; view touchesBegan:touches withEvent:event];
 
     release(env, pool);
 }
 
 fn handle_touches_move(env: &mut Environment, map: HashMap<FingerId, Coords>) {
-    let finger_id = 0;
-    if !map.contains_key(&finger_id) {
-        log!("TODO: TouchesMove handle other fingers");
-        return;
-    }
-    let coords = map.get(&finger_id).unwrap();
-
-    let Some(&touch) = env
-        .framework_state
-        .uikit
-        .ui_touch
-        .current_touches
-        .get(&finger_id)
-    else {
-        log!("Warning: Touch move event received but no current touch, ignoring.");
-        return;
-    };
-
-    log_dbg!("Touch move: {:?}", coords);
-
-    let location = CGPoint {
-        x: coords.0,
-        y: coords.1,
-    };
+    let pool: id = msg_class![env; NSAutoreleasePool new];
 
     let timestamp: NSTimeInterval = msg_class![env; NSProcessInfo systemUptime];
 
-    let view = env.objc.borrow::<UITouchHostObject>(touch).view;
-    let host_object = env.objc.borrow_mut::<UITouchHostObject>(touch);
-    host_object.previous_location = host_object.location;
-    host_object.location = location;
-    host_object.timestamp = timestamp;
-    host_object.phase = UITouchPhaseMoved;
+    let touches: id = msg_class![env; NSMutableSet allocWithZone:(MutVoidPtr::null())];
 
-    let pool: id = msg_class![env; NSAutoreleasePool new];
+    // view to set of touches for this view
+    let mut view_touches: HashMap<id, id> = HashMap::new();
 
-    let touches: id = msg_class![env; NSSet setWithObject:touch];
-    let event = ui_event::new_event(env, touches, view);
+    for (finger_id, coords) in map {
+        let Some(&touch) = env
+            .framework_state
+            .uikit
+            .ui_touch
+            .current_touches
+            .get(&finger_id)
+        else {
+            log!(
+                "Warning: Finger {} touch move event received but no current touch, ignoring.",
+                finger_id
+            );
+            continue;
+        };
+
+        log_dbg!("Finger {} touch move: {:?}", finger_id, coords);
+
+        let location = CGPoint {
+            x: coords.0,
+            y: coords.1,
+        };
+
+        let view = env.objc.borrow::<UITouchHostObject>(touch).view;
+        let host_object = env.objc.borrow_mut::<UITouchHostObject>(touch);
+        host_object.previous_location = host_object.location;
+        host_object.location = location;
+        host_object.timestamp = timestamp;
+        assert_eq!(host_object.phase, UITouchPhaseStationary);
+        host_object.phase = UITouchPhaseMoved;
+
+        let _: () = msg![env; touches addObject:touch];
+
+        if let Entry::Vacant(e) = view_touches.entry(view) {
+            let touches: id = msg_class![env; NSMutableSet allocWithZone:(MutVoidPtr::null())];
+            e.insert(touches);
+        }
+        let touches: id = *view_touches.get(&view).unwrap();
+        let _: () = msg![env; touches addObject:touch];
+    }
+
+    let event = ui_event::new_event(env, touches);
     autorelease(env, event);
 
-    log_dbg!(
-        "Sending [{:?} touchesMoved:{:?} withEvent:{:?}]",
-        view,
-        touches,
-        event
-    );
-    let _: () = msg![env; view touchesMoved:touches withEvent:event];
+    for (view, touches) in view_touches {
+        log_dbg!(
+            "Sending [{:?} touchesMoved:{:?} withEvent:{:?}]",
+            view,
+            touches,
+            event
+        );
+        let _: () = msg![env; view touchesMoved:touches withEvent:event];
+    }
 
     release(env, pool);
 }
 
 fn handle_touches_up(env: &mut Environment, map: HashMap<FingerId, Coords>) {
-    let finger_id = 0;
-    if !map.contains_key(&finger_id) {
-        log!("TODO: TouchesUp handle other fingers");
-        return;
-    }
-    let coords = map.get(&finger_id).unwrap();
-
-    let Some(&touch) = env
-        .framework_state
-        .uikit
-        .ui_touch
-        .current_touches
-        .get(&finger_id)
-    else {
-        log!("Warning: Touch up event received but no current touch, ignoring.");
-        return;
-    };
-
-    log_dbg!("Touch up: {:?}", coords);
-
-    let location = CGPoint {
-        x: coords.0,
-        y: coords.1,
-    };
+    let pool: id = msg_class![env; NSAutoreleasePool new];
 
     let timestamp: NSTimeInterval = msg_class![env; NSProcessInfo systemUptime];
 
-    let view = env.objc.borrow::<UITouchHostObject>(touch).view;
-    let host_object = env.objc.borrow_mut::<UITouchHostObject>(touch);
-    host_object.previous_location = host_object.location;
-    host_object.location = location;
-    host_object.timestamp = timestamp;
-    host_object.phase = UITouchPhaseEnded;
+    let touches: id = msg_class![env; NSMutableSet allocWithZone:(MutVoidPtr::null())];
 
-    let pool: id = msg_class![env; NSAutoreleasePool new];
+    // view to set of touches for this view
+    let mut view_touches: HashMap<id, id> = HashMap::new();
 
-    let touches: id = msg_class![env; NSSet setWithObject:touch];
-    let event = ui_event::new_event(env, touches, view);
+    for (finger_id, coords) in map {
+        let Some(&touch) = env
+            .framework_state
+            .uikit
+            .ui_touch
+            .current_touches
+            .get(&finger_id)
+        else {
+            log!(
+                "Warning: Finger {} touch up event received but no current touch, ignoring.",
+                finger_id
+            );
+            continue;
+        };
+
+        log_dbg!("Finger {} touch up: {:?}", finger_id, coords);
+
+        let location = CGPoint {
+            x: coords.0,
+            y: coords.1,
+        };
+
+        let view = env.objc.borrow::<UITouchHostObject>(touch).view;
+        let host_object = env.objc.borrow_mut::<UITouchHostObject>(touch);
+        host_object.previous_location = host_object.location;
+        host_object.location = location;
+        host_object.timestamp = timestamp;
+        assert_eq!(host_object.phase, UITouchPhaseStationary);
+        host_object.phase = UITouchPhaseEnded;
+
+        let _: () = msg![env; touches addObject:touch];
+
+        if let Entry::Vacant(e) = view_touches.entry(view) {
+            let touches: id = msg_class![env; NSMutableSet allocWithZone:(MutVoidPtr::null())];
+            e.insert(touches);
+        }
+        let touches: id = *view_touches.get(&view).unwrap();
+        let _: () = msg![env; touches addObject:touch];
+
+        let _ = &env
+            .framework_state
+            .uikit
+            .ui_touch
+            .current_touches
+            .remove(&finger_id);
+        retain(env, touch); // only owner now should be the NSSet
+    }
+
+    let event = ui_event::new_event(env, touches);
     autorelease(env, event);
 
-    env.framework_state
-        .uikit
-        .ui_touch
-        .current_touches
-        .remove(&finger_id);
-    release(env, touch); // only owner now should be the NSSet
-
-    log_dbg!(
-        "Sending [{:?} touchesEnded:{:?} withEvent:{:?}]",
-        view,
-        touches,
-        event
-    );
-    let _: () = msg![env; view touchesEnded:touches withEvent:event];
+    for (view, touches) in view_touches {
+        log_dbg!(
+            "Sending [{:?} touchesEnded:{:?} withEvent:{:?}]",
+            view,
+            touches,
+            event
+        );
+        let _: () = msg![env; view touchesEnded:touches withEvent:event];
+    }
 
     release(env, pool);
 }

--- a/src/frameworks/uikit/ui_view.rs
+++ b/src/frameworks/uikit/ui_view.rs
@@ -40,6 +40,7 @@ pub(super) struct UIViewHostObject {
     superview: id,
     clears_context_before_drawing: bool,
     user_interaction_enabled: bool,
+    multiple_touch_enabled: bool,
 }
 impl HostObject for UIViewHostObject {}
 impl Default for UIViewHostObject {
@@ -52,6 +53,7 @@ impl Default for UIViewHostObject {
             superview: nil,
             clears_context_before_drawing: true,
             user_interaction_enabled: true,
+            multiple_touch_enabled: false,
         }
     }
 }
@@ -171,9 +173,11 @@ pub const CLASSES: ClassExports = objc_classes! {
     env.objc.borrow_mut::<UIViewHostObject>(this).user_interaction_enabled = enabled;
 }
 
-// TODO: setMultipleTouchEnabled
-- (())setMultipleTouchEnabled:(bool)_enabled {
-    // TODO: enable multitouch
+- (bool)isMultipleTouchEnabled {
+    env.objc.borrow::<UIViewHostObject>(this).multiple_touch_enabled
+}
+- (())setMultipleTouchEnabled:(bool)enabled {
+    env.objc.borrow_mut::<UIViewHostObject>(this).multiple_touch_enabled = enabled;
 }
 
 - (())layoutSubviews {
@@ -258,6 +262,7 @@ pub const CLASSES: ClassExports = objc_classes! {
         subviews,
         clears_context_before_drawing: _,
         user_interaction_enabled: _,
+        multiple_touch_enabled: _,
     } = std::mem::take(env.objc.borrow_mut(this));
 
     release(env, layer);

--- a/src/options.rs
+++ b/src/options.rs
@@ -16,7 +16,7 @@ pub const OPTIONS_HELP: &str =
     include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/OPTIONS_HELP.txt"));
 
 /// Game controller button for `--button-to-touch=` option.
-#[derive(Hash, PartialEq, Eq)]
+#[derive(Copy, Clone, Hash, PartialEq, Eq, Debug)]
 pub enum Button {
     A,
     B,

--- a/src/window.rs
+++ b/src/window.rs
@@ -69,7 +69,7 @@ fn set_sdl2_orientation(orientation: DeviceOrientation) {
 }
 
 pub type FingerId = i64;
-type Coords = (f32, f32);
+pub type Coords = (f32, f32);
 
 #[derive(Debug)]
 pub enum Event {

--- a/src/window.rs
+++ b/src/window.rs
@@ -68,7 +68,13 @@ fn set_sdl2_orientation(orientation: DeviceOrientation) {
     );
 }
 
-pub type FingerId = i64;
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub enum FingerId {
+    Mouse,
+    Touch(i64),
+    VirtualCursor,
+    ButtonToTouch(crate::options::Button),
+}
 pub type Coords = (f32, f32);
 
 #[derive(Debug)]
@@ -387,14 +393,14 @@ impl Window {
                 } => {
                     let coords = transform_input_coords(self, (x as f32, y as f32), false);
                     log_dbg!("MouseButtonDown x {}, y {}, coords {:?}", x, y, coords);
-                    Event::TouchesDown(HashMap::from([(0, coords)]))
+                    Event::TouchesDown(HashMap::from([(FingerId::Mouse, coords)]))
                 }
                 E::MouseMotion {
                     x, y, mousestate, ..
                 } if mousestate.left() => {
                     let coords = transform_input_coords(self, (x as f32, y as f32), false);
                     log_dbg!("MouseMotion x {}, y {}, coords {:?}", x, y, coords);
-                    Event::TouchesMove(HashMap::from([(0, coords)]))
+                    Event::TouchesMove(HashMap::from([(FingerId::Mouse, coords)]))
                 }
                 E::MouseButtonUp {
                     x,
@@ -404,7 +410,7 @@ impl Window {
                 } => {
                     let coords = transform_input_coords(self, (x as f32, y as f32), false);
                     log_dbg!("MouseButtonUp x {}, y {}, coords {:?}", x, y, coords);
-                    Event::TouchesUp(HashMap::from([(0, coords)]))
+                    Event::TouchesUp(HashMap::from([(FingerId::Mouse, coords)]))
                 }
                 E::ControllerDeviceAdded { which, .. } => {
                     self.controller_added(which);
@@ -427,11 +433,17 @@ impl Window {
                     match event {
                         E::ControllerButtonUp { .. } => {
                             let coords = transform_input_coords(self, (x, y), true);
-                            Event::TouchesUp(HashMap::from([(0, coords)]))
+                            Event::TouchesUp(HashMap::from([(
+                                FingerId::ButtonToTouch(button),
+                                coords,
+                            )]))
                         }
                         E::ControllerButtonDown { .. } => {
                             let coords = transform_input_coords(self, (x, y), true);
-                            Event::TouchesDown(HashMap::from([(0, coords)]))
+                            Event::TouchesDown(HashMap::from([(
+                                FingerId::ButtonToTouch(button),
+                                coords,
+                            )]))
                         }
                         _ => unreachable!(),
                     }
@@ -489,7 +501,7 @@ impl Window {
                     let abs_coords = finger_absolute_coords(self, (x, y));
                     let coords = transform_input_coords(self, abs_coords, false);
                     log_dbg!("Finger event x {}, y {}, coords {:?}", x, y, coords);
-                    let mut map = HashMap::from([(finger_id, coords)]);
+                    let mut map = HashMap::from([(FingerId::Touch(finger_id), coords)]);
                     while let Some(next) = self.event_pump.poll_event() {
                         match next {
                             E::Unknown { .. } => (),
@@ -519,7 +531,7 @@ impl Window {
                             } if timestamp == curr_timestamp && next.is_same_kind_as(&event) => {
                                 let abs_coords = finger_absolute_coords(self, (x, y));
                                 let coords = transform_input_coords(self, abs_coords, false);
-                                map.insert(finger_id, coords);
+                                map.insert(FingerId::Touch(finger_id), coords);
                             }
                             E::MultiGesture { timestamp, .. } if timestamp == curr_timestamp => {
                                 // TODO: handle gestures
@@ -553,15 +565,15 @@ impl Window {
                 .push_back(match (pressed, pressed_changed, moved) {
                     (true, true, _) => {
                         let coords = transform_input_coords(self, (new_x, new_y), false);
-                        Event::TouchesDown(HashMap::from([(0, coords)]))
+                        Event::TouchesDown(HashMap::from([(FingerId::VirtualCursor, coords)]))
                     }
                     (false, true, _) => {
                         let coords = transform_input_coords(self, (new_x, new_y), false);
-                        Event::TouchesUp(HashMap::from([(0, coords)]))
+                        Event::TouchesUp(HashMap::from([(FingerId::VirtualCursor, coords)]))
                     }
                     (true, _, true) => {
                         let coords = transform_input_coords(self, (new_x, new_y), false);
-                        Event::TouchesMove(HashMap::from([(0, coords)]))
+                        Event::TouchesMove(HashMap::from([(FingerId::VirtualCursor, coords)]))
                     }
                     _ => return,
                 });

--- a/src/window.rs
+++ b/src/window.rs
@@ -379,7 +379,6 @@ impl Window {
             };
             self.event_queue.push_back(match event {
                 E::Quit { .. } => Event::Quit,
-                // TODO: support for multi-touch
                 E::MouseButtonDown {
                     x,
                     y,

--- a/src/window.rs
+++ b/src/window.rs
@@ -181,6 +181,9 @@ impl Window {
             sdl2::hint::set("SDL_ANDROID_BLOCK_ON_PAUSE", "0");
         }
 
+        // Separate mouse and touch events
+        sdl2::hint::set("SDL_TOUCH_MOUSE_EVENTS", "0");
+
         // SDL2 disables the screen saver by default, but iPhone OS enables
         // the idle timer that triggers sleep by default, so we turn it back on
         // here, and then the app can disable it if it wants to.
@@ -347,13 +350,33 @@ impl Window {
                 _ => None,
             }
         }
+        fn finger_absolute_coords(window: &Window, (x, y): (f32, f32)) -> (f32, f32) {
+            let (screen_width, screen_height) = window.window.drawable_size();
+            (screen_width as f32 * x, screen_height as f32 * y)
+        }
 
         let mut controller_updated = false;
+        // event_pump doesn't have a method to peek on events
+        // so, we keep track of an unconsumed one from a previous loop iteration
+        // FIXME: use peek_event() from even_subsystem
+        let mut previous_event: Option<sdl2::event::Event> = None;
         while self.enable_event_polling {
-            let Some(event) = self.event_pump.poll_event() else {
+            use sdl2::event::Event as E;
+            let event = if let Some(e) = previous_event.take() {
+                match e {
+                    E::Unknown { .. } => (),
+                    _ => log_dbg!("Consuming previous event: {:?}", e),
+                }
+                e
+            } else if let Some(e) = self.event_pump.poll_event() {
+                match e {
+                    E::Unknown { .. } => (),
+                    _ => log_dbg!("Consuming new event: {:?}", e),
+                }
+                e
+            } else {
                 break;
             };
-            use sdl2::event::Event as E;
             self.event_queue.push_back(match event {
                 E::Quit { .. } => Event::Quit,
                 // TODO: support for multi-touch
@@ -364,12 +387,14 @@ impl Window {
                     ..
                 } => {
                     let coords = transform_input_coords(self, (x as f32, y as f32), false);
+                    log_dbg!("MouseButtonDown x {}, y {}, coords {:?}", x, y, coords);
                     Event::TouchesDown(HashMap::from([(0, coords)]))
                 }
                 E::MouseMotion {
                     x, y, mousestate, ..
                 } if mousestate.left() => {
                     let coords = transform_input_coords(self, (x as f32, y as f32), false);
+                    log_dbg!("MouseMotion x {}, y {}, coords {:?}", x, y, coords);
                     Event::TouchesMove(HashMap::from([(0, coords)]))
                 }
                 E::MouseButtonUp {
@@ -379,6 +404,7 @@ impl Window {
                     ..
                 } => {
                     let coords = transform_input_coords(self, (x as f32, y as f32), false);
+                    log_dbg!("MouseButtonUp x {}, y {}, coords {:?}", x, y, coords);
                     Event::TouchesUp(HashMap::from([(0, coords)]))
                 }
                 E::ControllerDeviceAdded { which, .. } => {
@@ -432,6 +458,90 @@ impl Window {
                     self.high_priority_event = Some(Event::AppWillTerminate);
                     self.enable_event_polling = false;
                     continue;
+                }
+                E::FingerUp {
+                    timestamp,
+                    finger_id,
+                    x,
+                    y,
+                    ..
+                }
+                | E::FingerMotion {
+                    timestamp,
+                    finger_id,
+                    x,
+                    y,
+                    ..
+                }
+                | E::FingerDown {
+                    timestamp,
+                    finger_id,
+                    x,
+                    y,
+                    ..
+                } => {
+                    log_dbg!("Starting multi-touch for {:?}", event);
+                    // To implement multi-touch we accumulate here same touch events at the same
+                    // timestamp. This is consistent with UIKit API, but could be broken if events
+                    // come out of the order.
+                    // (in worst case we separate multi-touches in several ones)
+                    // TODO: handle out of order touches
+                    let curr_timestamp = timestamp;
+                    let abs_coords = finger_absolute_coords(self, (x, y));
+                    let coords = transform_input_coords(self, abs_coords, false);
+                    log_dbg!("Finger event x {}, y {}, coords {:?}", x, y, coords);
+                    let mut map = HashMap::from([(finger_id, coords)]);
+                    while let Some(next) = self.event_pump.poll_event() {
+                        match next {
+                            E::Unknown { .. } => (),
+                            _ => log_dbg!("Next possible multi-touch event: {:?}", next),
+                        }
+                        match next {
+                            E::FingerUp {
+                                timestamp,
+                                finger_id,
+                                x,
+                                y,
+                                ..
+                            }
+                            | E::FingerMotion {
+                                timestamp,
+                                finger_id,
+                                x,
+                                y,
+                                ..
+                            }
+                            | E::FingerDown {
+                                timestamp,
+                                finger_id,
+                                x,
+                                y,
+                                ..
+                            } if timestamp == curr_timestamp && next.is_same_kind_as(&event) => {
+                                let abs_coords = finger_absolute_coords(self, (x, y));
+                                let coords = transform_input_coords(self, abs_coords, false);
+                                map.insert(finger_id, coords);
+                            }
+                            E::MultiGesture { timestamp, .. } if timestamp == curr_timestamp => {
+                                // TODO: handle gestures
+                                continue;
+                            }
+                            _ => {
+                                // event_pump doesn't have a method to peek on events
+                                // so, we keep track of an unconsumed one from a previous loop iteration
+                                assert!(previous_event.is_none());
+                                previous_event = Some(next);
+                                break;
+                            }
+                        }
+                    }
+                    log_dbg!("Finishing multi-touch for {:?} with {:?}", event, map);
+                    match event {
+                        E::FingerUp { .. } => Event::TouchesUp(map),
+                        E::FingerMotion { .. } => Event::TouchesMove(map),
+                        E::FingerDown { .. } => Event::TouchesDown(map),
+                        _ => unreachable!(),
+                    }
                 }
                 _ => continue,
             })


### PR DESCRIPTION
This PR introduces the support for multi-touch

Notes:
- SDL events are polled sequentially and to implement multi-touch we accumulate here same touch events at the same timestamp. This is consistent with UIKit API, but could be broken if events come out of the order. (I haven't observed anything like this during the tests)
- On Android finger touch events do not produce mouse events anymore (as otherwise we would account for them twice)
- I verified that touch delivering is consistent with a real iOS device (iPad 2 2011, the oldest device i can build apps on)

Tested games:
- Wolf3d
- Earthworm Jim
- SMB (for regressions)