### PR TITLE
Adds --y-tilt-offset=24 to KataDama options

### DIFF
--- a/touchHLE_default_options.txt
+++ b/touchHLE_default_options.txt
@@ -51,7 +51,7 @@ com.atodab.actane: --landscape-left --button-to-touch=A,430,300 --button-to-touc
 com.idsoftware.wolf3d: --landscape-right
 
 # KataDama (I Love Katamari)
-com.namconetworks.katamari: --landscape-left --stabilize-virtual-cursor=0.1,10
+com.namconetworks.katamari: --landscape-left --stabilize-virtual-cursor=0.1,10 --y-tilt-offset=24
 
 # Wolfenstein RPG
 com.eamobile.wolfbv: --landscape-left --stabilize-virtual-cursor=0.1,10 --button-to-touch=A,240,160 --button-to-touch=B,240,280 --button-to-touch=X,26,280 --button-to-touch=Y,454,280 --button-to-touch=DPadLeft,34,178 --button-to-touch=DPadUp,76,140 --button-to-touch=DPadRight,116,180 --button-to-touch=DPadDown,76,220


### PR DESCRIPTION
Fixes an issue on PC with controller that it would walk forward when left stick is untouched and not walk backwards when left stick is pressed down.

Before fix video: https://youtu.be/yjJbecDOXgs
After fix video: https://youtu.be/V_zpKfL6snk

Change-Id: Id46e75ad6bf0e3343d6fc135f0cbef86eacd5f28