### PR TITLE
Fix read extended fopen flag

### DIFF
--- a/src/libc/stdio.rs
+++ b/src/libc/stdio.rs
@@ -61,7 +61,7 @@ fn fopen(env: &mut Environment, filename: ConstPtr<u8>, mode: ConstPtr<u8>) -> M
 
     let flags = match (basic_mode, plus) {
         (b'r', false) => O_RDONLY,
-        (b'r', true) => O_RDWR | O_APPEND,
+        (b'r', true) => O_RDWR,
         (b'w', false) => O_WRONLY | O_CREAT | O_TRUNC,
         (b'w', true) => O_RDWR | O_CREAT | O_TRUNC,
         (b'a', false) => O_WRONLY | O_APPEND | O_CREAT,


### PR DESCRIPTION
Hi I was messing around with touchHLE to run an old iOS port of ace attorney which i got running eventually but the changes are too obtrusive and are just a result of unimplemented framework functionalities and unhandled error edge cases if you're interested I could share the steps I took to get the game running but it isn't very difficult for one to replicate it.
anyways I digress the game's saves would not work properly and having a look at debug output from libc::stdio revealed that read extended was also appending to the file which definitely doesn't seem right so I thought i'd open this PR just in case.