### PR TITLE
Add controls for Earthworm Jim, Crash Kart story mode

### DIFF
--- a/touchHLE_default_options.txt
+++ b/touchHLE_default_options.txt
@@ -37,8 +37,8 @@ com.ooi.supermonkeyball: --landscape-left --y-tilt-offset=24 --button-to-touch=B
 smblite: --landscape-left --y-tilt-offset=24 --button-to-touch=B,470,160 --button-to-touch=Start,240,10
 
 # Crash Bandicoot Nitro Kart 3D
-# A = jump/drift, B = brake, Start = pause, Y = use item
-com.vgmobile.cnk2: --landscape-left --button-to-touch=A,240,160 --button-to-touch=B,240,310 --button-to-touch=Start,10,310 --button-to-touch=Y,470,310
+# A = jump/drift, B = brake, Start = pause, X/Y = use item
+com.vgmobile.cnk2: --landscape-left --button-to-touch=A,240,160 --button-to-touch=B,240,310 --button-to-touch=Start,10,310 --button-to-touch=Y,470,310 --button-to-touch=X,446,30
 
 # Mystery Mania
 com.ea.mysterymania.inc: --landscape-left
@@ -80,3 +80,7 @@ com.bestsungame.warriornationblade:  --button-to-touch=DPadLeft,50,285 --button-
 
 # Resident Evil 4
 jp.co.capcom.res4: --landscape-left --stabilize-virtual-cursor=0.1,10 --button-to-touch=A,430,280 --button-to-touch=B,440,200 --button-to-touch=X,360,200 --button-to-touch=Y,440,150 --button-to-touch=DPadLeft,25,247 --button-to-touch=DPadUp,72,200 --button-to-touch=DPadRight,120,247 --button-to-touch=DPadDown,72,300
+
+# Earthworm Jim
+# Up/Down/Left/Right = Move, A = Jump, B = Whip, X = Fire
+com.gameloft.Earthworm: --landscape-left --button-to-touch=DPadUp,72,194 --button-to-touch=DPadDown,72,278 --button-to-touch=DPadLeft,30,238 --button-to-touch=DPadRight,110,238 --button-to-touch=A,442,284 --button-to-touch=X,378,248 --button-to-touch=B,442,212 --button-to-touch=Start,448,32


### PR DESCRIPTION
Adds a new control profile for Earthworm Jim based on the SNES version controls, and adds a second item input for Crash Kart as the item icon is in a different location in story mode.

Story mode
![image](https://github.com/touchHLE/touchHLE/assets/33245078/e1e46e62-0114-45b1-8654-ab3390dbb965)

Other modes
![image](https://github.com/touchHLE/touchHLE/assets/33245078/7789d5e2-889d-45f8-8866-ff6de709fc80)
