### PR TITLE
Fix Android CI build

### DIFF
--- a/.github/workflows/touchHLE_release.yml
+++ b/.github/workflows/touchHLE_release.yml
@@ -65,6 +65,12 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0 # touchHLE's git-describe versioning needs tag history
+    - uses: nttld/setup-ndk@v1
+      id: setup-ndk
+      with:
+        # The version should match the ndkVersion defined in `android\app\build.gradle`
+        ndk-version: r25c
+        link-to-sdk: true
     - name: Check formatting
       run: dev-scripts/format.sh --check
     - name: Get Submodules
@@ -106,6 +112,9 @@ jobs:
     # (would have to run on Android 😰).
     - name: Build for Android
       run: cd android && ../gradle/gradle-7.3/bin/gradle assembleRelease && mv app/build/outputs/apk/release/app-release.apk ../touchHLE.apk
+      env:
+        ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+        ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
     - uses: actions/upload-artifact@v3
       with:
         name: touchHLE_Android_AArch64

--- a/.github/workflows/touchHLE_release.yml
+++ b/.github/workflows/touchHLE_release.yml
@@ -108,7 +108,7 @@ jobs:
       run: cd android && ../gradle/gradle-7.3/bin/gradle assembleRelease && mv app/build/outputs/apk/release/app-release.apk ../touchHLE.apk
       env:
         # The version should match the ndkVersion defined in `android\app\build.gradle`
-        ANDROID_NDK_ROOT: $ANDROID_SDK_ROOT'/ndk/25.2.9519653'
+        ANDROID_NDK_ROOT: '${{ env.ANDROID_SDK_ROOT }}/ndk/25.2.9519653'
     - uses: actions/upload-artifact@v3
       with:
         name: touchHLE_Android_AArch64

--- a/.github/workflows/touchHLE_release.yml
+++ b/.github/workflows/touchHLE_release.yml
@@ -108,7 +108,7 @@ jobs:
       run: cd android && ../gradle/gradle-7.3/bin/gradle assembleRelease && mv app/build/outputs/apk/release/app-release.apk ../touchHLE.apk
       env:
         # The version should match the ndkVersion defined in `android\app\build.gradle`
-        ANDROID_NDK_ROOT: '${{ env.ANDROID_SDK_ROOT }}/ndk/25.2.9519653'
+        ANDROID_NDK_ROOT: '/usr/local/lib/android/sdk/ndk/25.2.9519653'
     - uses: actions/upload-artifact@v3
       with:
         name: touchHLE_Android_AArch64

--- a/.github/workflows/touchHLE_release.yml
+++ b/.github/workflows/touchHLE_release.yml
@@ -65,12 +65,6 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0 # touchHLE's git-describe versioning needs tag history
-    - uses: nttld/setup-ndk@v1
-      id: setup-ndk
-      with:
-        # The version should match the ndkVersion defined in `android\app\build.gradle`
-        ndk-version: r25c
-        link-to-sdk: true
     - name: Check formatting
       run: dev-scripts/format.sh --check
     - name: Get Submodules
@@ -113,8 +107,8 @@ jobs:
     - name: Build for Android
       run: cd android && ../gradle/gradle-7.3/bin/gradle assembleRelease && mv app/build/outputs/apk/release/app-release.apk ../touchHLE.apk
       env:
-        ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
-        ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
+        # The version should match the ndkVersion defined in `android\app\build.gradle`
+        ANDROID_NDK_ROOT: $ANDROID_SDK_ROOT'/ndk/25.2.9519653'
     - uses: actions/upload-artifact@v3
       with:
         name: touchHLE_Android_AArch64


### PR DESCRIPTION
Github runner seems to bump a vendored version of NDK to version 27, resulting in an incorrect value of ANDROID_NDK_ROOT being set.

The problem is fixed by explicitly setting that variable with a path to NDK with a correct version (the same version as in build.gradle file "25.2.9519653")