### PR TITLE
Fix Android CI build (again)

### DIFF
--- a/.github/workflows/touchHLE_release.yml
+++ b/.github/workflows/touchHLE_release.yml
@@ -113,6 +113,8 @@ jobs:
       run: 7z -oandroid-ndk x android-ndk-r25c-linux.zip
     - name: Link Android NDK
       run: ln -s android-ndk/android-ndk-r25c /usr/local/lib/android/sdk/ndk/25.2.9519653
+    - name: Test 3
+      run: ls -la /usr/local/lib/android/sdk/ndk/25.2.9519653
     # Why isn't there a command for this?
     - name: Generate local.properties file
       run: echo 'sdk.dir='$ANDROID_SDK_ROOT > android/local.properties

--- a/.github/workflows/touchHLE_release.yml
+++ b/.github/workflows/touchHLE_release.yml
@@ -98,6 +98,21 @@ jobs:
     - if: ${{ steps.cache-gradle.outputs.cache-hit != 'true' }}
       name: Extract Gradle
       run: 7z -ogradle x gradle-7.3-bin.zip
+    # We need to instal correct version of Android NDK manually
+    - name: Try to get a cached copy of Android NDK
+      id: cache-android-ndk
+      uses: actions/cache@v3
+      with:
+        path: android-ndk
+        key: android-ndk-r25c
+    - if: ${{ steps.cache-android-ndk.outputs.cache-hit != 'true' }}
+      name: Download Android NDK
+      run: curl -L -o android-ndk-r25c-linux.zip "https://dl.google.com/android/repository/android-ndk-r25c-linux.zip"
+    - if: ${{ steps.cache-android-ndk.outputs.cache-hit != 'true' }}
+      name: Extract Android NDK
+      run: 7z -oandroid-ndk x android-ndk-r25c-linux.zip
+    - name: Link Android NDK
+      run: ln -s android-ndk/android-ndk-r25c /usr/local/lib/android/sdk/ndk/25.2.9519653
     # Why isn't there a command for this?
     - name: Generate local.properties file
       run: echo 'sdk.dir='$ANDROID_SDK_ROOT > android/local.properties

--- a/.github/workflows/touchHLE_release.yml
+++ b/.github/workflows/touchHLE_release.yml
@@ -112,7 +112,7 @@ jobs:
       name: Extract Android NDK
       run: 7z -oandroid-ndk x android-ndk-r25c-linux.zip
     - name: Link Android NDK
-      run: ln -s android-ndk/android-ndk-r25c /usr/local/lib/android/sdk/ndk/25.2.9519653
+      run: ln -s ./android-ndk/android-ndk-r25c /usr/local/lib/android/sdk/ndk/25.2.9519653
     - name: Test 3
       run: ls -la /usr/local/lib/android/sdk/ndk/25.2.9519653
     # Why isn't there a command for this?

--- a/.github/workflows/touchHLE_release.yml
+++ b/.github/workflows/touchHLE_release.yml
@@ -112,9 +112,7 @@ jobs:
       name: Extract Android NDK
       run: 7z -oandroid-ndk x android-ndk-r25c-linux.zip
     - name: Link Android NDK
-      run: ln -s $PWD'/android-ndk/android-ndk-r25c' /usr/local/lib/android/sdk/ndk/25.2.9519653
-    - name: Test 3
-      run: ls -la /usr/local/lib/android/sdk/ndk/25.2.9519653
+      run: ln -s $PWD'/android-ndk/android-ndk-r25c' $ANDROID_SDK_ROOT'/ndk/25.2.9519653'
     # Why isn't there a command for this?
     - name: Generate local.properties file
       run: echo 'sdk.dir='$ANDROID_SDK_ROOT > android/local.properties

--- a/.github/workflows/touchHLE_release.yml
+++ b/.github/workflows/touchHLE_release.yml
@@ -112,7 +112,7 @@ jobs:
       name: Extract Android NDK
       run: 7z -oandroid-ndk x android-ndk-r25c-linux.zip
     - name: Link Android NDK
-      run: ln -s ./android-ndk/android-ndk-r25c /usr/local/lib/android/sdk/ndk/25.2.9519653
+      run: ln -s $PWD'/android-ndk/android-ndk-r25c' /usr/local/lib/android/sdk/ndk/25.2.9519653
     - name: Test 3
       run: ls -la /usr/local/lib/android/sdk/ndk/25.2.9519653
     # Why isn't there a command for this?


### PR DESCRIPTION
CI runner doesn't include anymore the version of Android NDK which we're using, so we need to install it manually

Change-Id: I92749c107ca9ff45053454db5f8043b1924e286c