### PR TITLE
Help "Cause of Death" boot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ mach_object = "0.1.17"
 plist = "1.3.1"
 zip = { version = "0.6.4", default-features = false, features = ["deflate"] }
 rusttype = "0.9.3"
+owned_ttf_parser = "0.15.2"
 # While most Symphonia codecs are (likely) unpatented/have freely licenseable 
 # patents as of 2024, all of the AAC profiles except AAC-LC (likely) have 
 # active patent claims. The "aac" feature only enables AAC-LC, so it's should 

--- a/src/abi.rs
+++ b/src/abi.rs
@@ -180,6 +180,9 @@ impl_CallFromGuest!(0 => P0, 1 => P1, 2 => P2, 3 => P3, 4 => P4, 5 => P5);
 impl_CallFromGuest!(0 => P0, 1 => P1, 2 => P2, 3 => P3, 4 => P4, 5 => P5, 6 => P6);
 impl_CallFromGuest!(0 => P0, 1 => P1, 2 => P2, 3 => P3, 4 => P4, 5 => P5, 6 => P6, 7 => P7);
 impl_CallFromGuest!(0 => P0, 1 => P1, 2 => P2, 3 => P3, 4 => P4, 5 => P5, 6 => P6, 7 => P7, 8 => P8);
+impl_CallFromGuest!(0 => P0, 1 => P1, 2 => P2, 3 => P3, 4 => P4, 5 => P5, 6 => P6, 7 => P7, 8 => P8, 9 => P9);
+impl_CallFromGuest!(0 => P0, 1 => P1, 2 => P2, 3 => P3, 4 => P4, 5 => P5, 6 => P6, 7 => P7, 8 => P8, 9 => P9, 10 => P10);
+impl_CallFromGuest!(0 => P0, 1 => P1, 2 => P2, 3 => P3, 4 => P4, 5 => P5, 6 => P6, 7 => P7, 8 => P8, 9 => P9, 10 => P10, 11 => P11);
 
 /// This trait represents a guest or host function that can be called from host
 /// code, but using the guest ABI. See [CallFromGuest], which this is the

--- a/src/dyld.rs
+++ b/src/dyld.rs
@@ -28,7 +28,7 @@ use crate::cpu::Cpu;
 use crate::frameworks::foundation::ns_string;
 use crate::mach_o::{MachO, SectionType};
 use crate::mem::{ConstVoidPtr, GuestUSize, Mem, MutPtr, Ptr};
-use crate::objc::{nil, ObjC};
+use crate::objc::{nil, HostIMP, ObjC};
 use crate::Environment;
 use std::collections::HashMap;
 
@@ -167,12 +167,28 @@ fn write_return_to_host_routine(mem: &mut Mem, svc: u32) -> GuestFunction {
     assert!(!ptr.is_thumb());
     ptr
 }
+
+pub enum HostFn {
+    Function(HostFunction),
+    Imp(&'static dyn HostIMP),
+}
+
+impl Clone for HostFn {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl Copy for HostFn {
+
+}
+
 pub struct Dyld {
     /// List of host functions that have been "linked" and had SVCs assigned.
     ///
     /// The `&'static str` part here is purely for debugging and could be
     /// removed in release builds if it's ever necessary.
-    linked_host_functions: Vec<(&'static str, HostFunction)>,
+    linked_host_functions: Vec<(&'static str, HostFn)>,
     return_to_host_routine: Option<GuestFunction>,
     thread_exit_routine: Option<GuestFunction>,
     constants_to_link_later: Vec<(MutPtr<ConstVoidPtr>, &'static HostConstant)>,
@@ -474,9 +490,9 @@ impl Dyld {
         cpu: &mut Cpu,
         svc_pc: u32,
         svc: u32,
-    ) -> Option<HostFunction> {
+    ) -> Option<HostFn> {
         match svc {
-            Self::SVC_LAZY_LINK => self.do_lazy_link(bins, mem, cpu, svc_pc),
+            Self::SVC_LAZY_LINK => self.do_lazy_link(bins, mem, cpu, svc_pc).map(|f| HostFn::Function(f)),
             Self::SVC_THREAD_EXIT | Self::SVC_RETURN_TO_HOST => unreachable!(), // don't handle here
             Self::SVC_LINKED_FUNCTIONS_BASE.. => {
                 let f = self
@@ -577,7 +593,7 @@ impl Dyld {
             // Allocate an SVC ID for this host function
             let idx: u32 = self.linked_host_functions.len().try_into().unwrap();
             let svc = idx + Self::SVC_LINKED_FUNCTIONS_BASE;
-            self.linked_host_functions.push((symbol, f));
+            self.linked_host_functions.push((symbol, HostFn::Function(f)));
 
             // Rewrite stub function to call this host function
             let stub_function_ptr: MutPtr<u32> = Ptr::from_bits(svc_pc);
@@ -662,7 +678,27 @@ impl Dyld {
         // Allocate an SVC ID for this host function
         let idx: u32 = self.linked_host_functions.len().try_into().unwrap();
         let svc = idx + Self::SVC_LINKED_FUNCTIONS_BASE;
-        self.linked_host_functions.push((symbol, f));
+        self.linked_host_functions.push((symbol, HostFn::Function(f)));
+
+        // Create guest function to call this host function
+        let function_ptr = mem.alloc(8);
+        let function_ptr: MutPtr<u32> = function_ptr.cast();
+        mem.write(function_ptr + 0, encode_a32_svc(svc));
+        mem.write(function_ptr + 1, encode_a32_ret());
+
+        GuestFunction::from_addr_with_thumb_bit(function_ptr.to_bits())
+    }
+
+    pub fn create_guest_hostimp(
+        &mut self,
+        mem: &mut Mem,
+        symbol: &'static str,
+        f: &'static dyn HostIMP,
+    ) -> GuestFunction {
+        // Allocate an SVC ID for this host function
+        let idx: u32 = self.linked_host_functions.len().try_into().unwrap();
+        let svc = idx + Self::SVC_LINKED_FUNCTIONS_BASE;
+        self.linked_host_functions.push((symbol, HostFn::Imp(f)));
 
         // Create guest function to call this host function
         let function_ptr = mem.alloc(8);

--- a/src/dyld/constant_lists.rs
+++ b/src/dyld/constant_lists.rs
@@ -20,6 +20,7 @@ pub const CONSTANT_LISTS: &[super::ConstantExports] = &[
     core_animation::ca_animation::CONSTANTS,
     core_animation::ca_layer::CONSTANTS,
     core_animation::ca_media_timing_function::CONSTANTS,
+    core_animation::ca_transform::CONSTANTS,
     core_foundation::cf_allocator::CONSTANTS,
     core_foundation::cf_bundle::CONSTANTS,
     core_foundation::cf_dictionary::CONSTANTS,

--- a/src/dyld/function_lists.rs
+++ b/src/dyld/function_lists.rs
@@ -6,10 +6,7 @@
 //! Separate module just for the function lists, since this will probably be a
 //! very long and frequently-updated list.
 
-use crate::frameworks::{
-    audio_toolbox, core_foundation, core_graphics, dnssd, foundation, openal, opengles,
-    system_configuration, uikit,
-};
+use crate::frameworks::{audio_toolbox, core_animation, core_foundation, core_graphics, dnssd, foundation, openal, opengles, system_configuration, uikit};
 use crate::libc;
 
 /// All the lists of functions that the linker should search through.
@@ -85,6 +82,9 @@ pub const FUNCTION_LISTS: &[super::FunctionExports] = &[
     core_graphics::cg_data_provider::FUNCTIONS,
     core_graphics::cg_geometry::FUNCTIONS,
     core_graphics::cg_image::FUNCTIONS,
+    core_graphics::cg_font::FUNCTIONS,
+    core_animation::ca_transform::FUNCTIONS,
+    core_animation::ca_animation::FUNCTIONS,
     dnssd::FUNCTIONS,
     foundation::FUNCTIONS,
     foundation::ns_exception::FUNCTIONS,

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -23,6 +23,7 @@ use std::time::{Duration, Instant};
 
 use crate::libc::pthread::cond::pthread_cond_t;
 pub use mutex::{MutexId, MutexType, PTHREAD_MUTEX_DEFAULT};
+use crate::dyld::HostFn;
 
 /// Index into the [Vec] of threads. Thread 0 is always the main thread.
 pub type ThreadId = usize;
@@ -999,7 +1000,10 @@ impl Environment {
                             let was_in_host_function =
                                 self.threads[self.current_thread].in_host_function;
                             self.threads[self.current_thread].in_host_function = true;
-                            f.call_from_guest(self);
+                            match f {
+                                HostFn::Function(f) => {f.call_from_guest(self)}
+                                HostFn::Imp(f) => {f.call_from_guest(self)}
+                            }
                             self.threads[self.current_thread].in_host_function =
                                 was_in_host_function;
                             // Host function might have put the thread to sleep.

--- a/src/font.rs
+++ b/src/font.rs
@@ -16,9 +16,11 @@
 use crate::paths;
 use rusttype::{Point, Scale};
 use std::io::Read;
+use owned_ttf_parser::{AsFaceRef, GlyphId, Rect, Tag};
 
 pub struct Font {
     font: rusttype::Font<'static>,
+    inner_font: owned_ttf_parser::OwnedFace,
 }
 
 pub enum TextAlignment {
@@ -79,11 +81,15 @@ impl Font {
             );
         }
 
-        let Some(font) = rusttype::Font::try_from_vec(bytes) else {
+        let Some(font) = rusttype::Font::try_from_vec(bytes.clone()) else {
             panic!("Couldn't parse bundled font file {:?}. This probably means the file is corrupt. Try re-downloading it.", path);
         };
 
-        Font { font }
+        let Ok(inner_font) = owned_ttf_parser::OwnedFace::from_vec(bytes, 0) else {
+            panic!("Couldn't parse bundled font file {:?}. This probably means the file is corrupt. Try re-downloading it.", path);
+        };
+
+        Font { font, inner_font }
     }
 
     pub fn mono_regular() -> Font {
@@ -315,6 +321,45 @@ impl Font {
             line_height * (lines.len() as f32) + line_gap * (lines.len().saturating_sub(1) as f32);
 
         (width, height)
+    }
+    
+    pub fn get_raw_table(&self, tag: u32) -> Vec<u8> {
+        let tag = Tag::from_bytes_lossy(&tag.to_be_bytes());
+        self.inner_font.as_face_ref().table_data(tag).unwrap().to_vec()
+    }
+    
+    pub fn name(&self) -> String {
+        String::from_utf8(self.inner_font.as_face_ref().names().get(0).unwrap().name.to_vec()).unwrap()
+    }
+
+    pub fn glyph_size(&self, glyph: GlyphId) -> Rect {
+        self.inner_font.as_face_ref().glyph_bounding_box(glyph).or_else(|| {
+            self.inner_font.as_face_ref().glyph_bounding_box(self.get_glyph('a').unwrap())
+        }).unwrap()
+    }
+
+    pub fn get_glyph(&self, char: char) -> Option<GlyphId> {
+        self.inner_font.as_face_ref().glyph_index(char)
+    }
+
+    pub fn advance_unscaled(&self, glyph_id: u16) -> i32 {
+        self.inner_font.as_face_ref().glyph_hor_advance(GlyphId(glyph_id)).unwrap() as i32
+    }
+
+    pub fn units_per_em(&self) -> u16 {
+        self.inner_font.as_face_ref().units_per_em()
+    }
+
+    pub fn ascent_unscaled(&self) -> i32 {
+        self.inner_font.as_face_ref().ascender() as i32
+    }
+
+    pub fn descent_unscaled(&self) -> i32 {
+        self.inner_font.as_face_ref().descender() as i32
+    }
+
+    pub fn cap_height(&self) -> i32 {
+        self.inner_font.as_face_ref().height() as i32
     }
 
     /// Draw text. Calls the provided callback for each glyph that is to be

--- a/src/font.rs
+++ b/src/font.rs
@@ -449,4 +449,85 @@ impl Font {
             line_y += line_height + line_gap;
         }
     }
+    
+    /// Draw glyph. Calls the provided callback for each glyph that is to be
+    /// drawn. Assumes y starts at the bottom-left corner and points upwards.
+    pub fn draw_glyphs<F: FnMut(RasterGlyph)>(
+        &self,
+        font_size: f32,
+        glyphs: &[GlyphId],
+        origin: (f32, f32),
+        wrap: Option<(f32, WrapMode)>,
+        alignment: TextAlignment,
+        mut draw_glyph: F,
+    ) {
+        // TODO: This code has gone through a rather traumatic series of y sign
+        //       flips and might benefit from refactoring for clarity?
+
+        let mut line_y = self.font.v_metrics(scale(font_size)).ascent;
+        let (line_height, line_gap) = self.line_height_and_gap(font_size);
+
+        // RustType requires a "draw pixel" callback that will be called for
+        // each pixel in the glyph's bounding box, in left-to-right
+        // top-to-bottom order. This is unfortunately incompatible with
+        // touchHLE's code which needs to be able to sample the pixels in any
+        // order in order to support rotation. This is worked around by creating
+        // a temporary bitmap for the glyph, and then the caller of this
+        // function can provide a "draw glyph" callback that can do whatever it
+        // wants with this bitmap.
+        // TODO: Do we need to increase the font size when scale transforms are
+        //       used, to avoid blurry text?
+        let mut glyph_bitmap: Vec<f32> = Vec::new();
+        let mut cumulative_x = 0.0;
+
+        for &glyph in glyphs {
+            let positioned_glyph = self.font
+                .glyph(glyph)
+                .scaled(scale(font_size))
+                .positioned(Point {
+                    x: origin.0 + cumulative_x,
+                    y: 0.0,
+                });
+            let Some(glyph_bounds) = positioned_glyph.pixel_bounding_box() else {
+                continue;
+            };
+            // y needs to be flipped to point up
+            let glyph_height = glyph_bounds.height();
+            let x_offset = glyph_bounds.min.x;
+            let y_offset = ((origin.1 + line_y).round() as i32) + glyph_bounds.max.y;
+
+            // TODO: Refactor this method to support y clipping too.
+            // It's not mandatory since the caller can do it, but it would
+            // be more efficient.
+            if let Some((wrap_width, _)) = wrap {
+                if glyph_bounds.min.x as f32 > origin.0 + wrap_width {
+                    // Avoid wasting effort on glyphs that are entirely
+                    // clipped. Partial clipping is the responsibility of
+                    // the draw_glyph implementation.
+                    continue;
+                }
+            }
+
+            let glyph_bitmap_bounds = (
+                glyph_bounds.width() as usize,
+                glyph_bounds.height() as usize,
+            );
+            glyph_bitmap.clear();
+            glyph_bitmap.resize(glyph_bitmap_bounds.0 * glyph_bitmap_bounds.1, 0.0);
+
+            positioned_glyph.draw(|x, y, coverage| {
+                glyph_bitmap[y as usize * glyph_bitmap_bounds.0 + x as usize] = coverage;
+            });
+
+            let raster_glyph = RasterGlyph {
+                origin: (x_offset as f32, y_offset as f32 - glyph_height as f32),
+                dimensions: (glyph_bitmap_bounds.0 as _, glyph_bitmap_bounds.1 as _),
+                pixels: &glyph_bitmap,
+            };
+
+            draw_glyph(raster_glyph);
+            cumulative_x += glyph_bounds.width() as f32;
+        }
+        line_y += line_height + line_gap;
+    }
 }

--- a/src/frameworks/core_animation.rs
+++ b/src/frameworks/core_animation.rs
@@ -12,6 +12,7 @@ pub mod ca_animation;
 pub mod ca_eagl_layer;
 pub mod ca_layer;
 pub mod ca_media_timing_function;
+pub mod ca_transform;
 
 mod composition;
 pub use composition::recomposite_if_necessary;

--- a/src/frameworks/core_animation/ca_animation.rs
+++ b/src/frameworks/core_animation/ca_animation.rs
@@ -25,7 +25,14 @@ const kCATransitionMoveIn: &str = "kCATransitionMoveIn";
 const kCATransitionPush: &str = "kCATransitionPush";
 const kCATransitionReveal: &str = "kCATransitionReveal";
 
-/// `CATransitionType` values.
+type CAAnimationCalculationModeType = id;
+const kCAAnimationLinear: &str = "kCAAnimationLinear";
+
+type CAMediaTimingFillModeType = id;
+const kCAFillModeBoth: &str = "kCAFillModeBoth";
+const kCAFillModeForwards: &str = "kCAFillModeForwards";
+
+/// Constant values.
 pub const CONSTANTS: ConstantExports = &[
     (
         "_kCATransitionFade",
@@ -43,6 +50,18 @@ pub const CONSTANTS: ConstantExports = &[
         "_kCATransitionReveal",
         HostConstant::NSString(kCATransitionReveal),
     ),
+    (
+        "_kCAAnimationLinear",
+        HostConstant::NSString(kCAAnimationLinear),
+    ),
+    (
+        "_kCAFillModeBoth",
+        HostConstant::NSString(kCAFillModeBoth),
+    ),
+    (
+        "_kCAFillModeForwards",
+        HostConstant::NSString(kCAFillModeForwards),
+    ),
 ];
 
 #[derive(Default)]
@@ -53,8 +72,8 @@ struct CAAnimationHostObject {
     repeat_count: f32,
     duration: CFTimeInterval,
     is_removed_on_completion: bool,
-    fill_mode: CFStringRef,
-    calculation_mode: CFStringRef,
+    fill_mode: CAMediaTimingFillModeType,
+    calculation_mode: CAAnimationCalculationModeType,
 }
 impl HostObject for CAAnimationHostObject {}
 
@@ -137,17 +156,17 @@ pub const CLASSES: ClassExports = objc_classes! {
     env.objc.borrow::<CAAnimationHostObject>(this).is_removed_on_completion
 }
 
-- (())setFillMode:(CFStringRef)mode {
+- (())setFillMode:(CAMediaTimingFillModeType)mode {
     env.objc.borrow_mut::<CAAnimationHostObject>(this).fill_mode = mode
 }
-- (CFStringRef)fillMode {
+- (CAMediaTimingFillModeType)fillMode {
     env.objc.borrow::<CAAnimationHostObject>(this).fill_mode
 }
 
-- (())setCalculationMode:(CFStringRef)mode {
+- (())setCalculationMode:(CAAnimationCalculationModeType)mode {
     env.objc.borrow_mut::<CAAnimationHostObject>(this).calculation_mode = mode
 }
-- (CFStringRef)calculationMode {
+- (CAAnimationCalculationModeType)calculationMode {
     env.objc.borrow::<CAAnimationHostObject>(this).calculation_mode
 }
 

--- a/src/frameworks/core_animation/ca_animation.rs
+++ b/src/frameworks/core_animation/ca_animation.rs
@@ -5,14 +5,19 @@
  */
 //! `CAAnimation` and its subclasses
 
-use crate::dyld::{ConstantExports, HostConstant};
+use crate::dyld::{ConstantExports, FunctionExports, HostConstant};
 use crate::frameworks::core_foundation::time::CFTimeInterval;
 use crate::frameworks::foundation::ns_string::to_rust_string;
 use crate::frameworks::foundation::NSTimeInterval;
 use crate::objc::{
     autorelease, id, msg, nil, objc_classes, release, retain, ClassExports, HostObject, NSZonePtr,
 };
-use crate::{impl_HostObject_with_superclass, msg_super};
+use crate::{export_c_func, impl_HostObject_with_superclass, msg_super};
+use crate::environment::Environment;
+use crate::frameworks::core_foundation::cf_string::CFStringRef;
+use crate::frameworks::core_graphics::CGFloat;
+use crate::libc::mach_time::mach_absolute_time;
+use crate::mem::MutPtr;
 
 type CATransitionType = id; // NSString*
 const kCATransitionFade: &str = "kCATransitionFade";
@@ -47,6 +52,9 @@ struct CAAnimationHostObject {
     autoreverses: bool,
     repeat_count: f32,
     duration: CFTimeInterval,
+    is_removed_on_completion: bool,
+    fill_mode: CFStringRef,
+    calculation_mode: CFStringRef,
 }
 impl HostObject for CAAnimationHostObject {}
 
@@ -65,6 +73,13 @@ struct CABasicAnimationHostObject {
     to_value: id,
 }
 impl_HostObject_with_superclass!(CABasicAnimationHostObject);
+
+#[derive(Default)]
+struct CAKeyframeAnimationHostObject {
+    superclass: CAPropertyAnimationHostObject,
+    duration: CGFloat,
+}
+impl_HostObject_with_superclass!(CAKeyframeAnimationHostObject);
 
 pub const CLASSES: ClassExports = objc_classes! {
 
@@ -113,6 +128,35 @@ pub const CLASSES: ClassExports = objc_classes! {
 - (())setDuration:(CFTimeInterval)duration {
     log_dbg!("[(CAAnimation*){:?} setDuration:{:?}]", this, duration);
     env.objc.borrow_mut::<CAAnimationHostObject>(this).duration = duration;
+}
+
+- (())setRemovedOnCompletion:(bool)removed {
+    env.objc.borrow_mut::<CAAnimationHostObject>(this).is_removed_on_completion = removed;
+}
+- (bool)isRemovedOnCompletion {
+    env.objc.borrow::<CAAnimationHostObject>(this).is_removed_on_completion
+}
+
+- (())setFillMode:(CFStringRef)mode {
+    env.objc.borrow_mut::<CAAnimationHostObject>(this).fill_mode = mode
+}
+- (CFStringRef)fillMode {
+    env.objc.borrow::<CAAnimationHostObject>(this).fill_mode
+}
+
+- (())setCalculationMode:(CFStringRef)mode {
+    env.objc.borrow_mut::<CAAnimationHostObject>(this).calculation_mode = mode
+}
+- (CFStringRef)calculationMode {
+    env.objc.borrow::<CAAnimationHostObject>(this).calculation_mode
+}
+
+- (())setValues:(MutPtr<id>)mode {
+    log!("Ignoring [(CAAnimation*){:?} setValues:{:?}]", this, mode);
+}
+
+- (())setKeyTimes:(MutPtr<id>)mode {
+    log!("Ignoring [(CAAnimation*){:?} setKeyTimes:{:?}]", this, mode);
 }
 
 - (())dealloc {
@@ -213,6 +257,22 @@ pub const CLASSES: ClassExports = objc_classes! {
 @end
 
 
+@implementation CAKeyframeAnimation : CAPropertyAnimation
++ (id)allocWithZone:(NSZonePtr)_zone {
+    let host_object = Box::<CAKeyframeAnimationHostObject>::default();
+    env.objc.alloc_object(this, host_object, &mut env.mem)
+}
+
+- (CGFloat) duration {
+    env.objc.borrow::<CAKeyframeAnimationHostObject>(this).duration
+}
+- (()) setDuration:(CGFloat)duration {
+    env.objc.borrow_mut::<CAKeyframeAnimationHostObject>(this).duration = duration
+
+}
+@end
+
+
 @implementation CATransition : CAAnimation
 
 + (id)animation {
@@ -231,3 +291,11 @@ pub const CLASSES: ClassExports = objc_classes! {
 @end
 
 };
+
+fn CACurrentMediaTime(env: &mut Environment) -> CFTimeInterval {
+    mach_absolute_time(env) as f64 / 1e9f64
+}
+
+pub const FUNCTIONS: FunctionExports = &[
+    export_c_func!(CACurrentMediaTime())
+];

--- a/src/frameworks/core_animation/ca_layer.rs
+++ b/src/frameworks/core_animation/ca_layer.rs
@@ -17,11 +17,12 @@ use crate::frameworks::core_graphics::cg_context::{
 use crate::frameworks::core_graphics::cg_image::{
     kCGImageAlphaPremultipliedLast, kCGImageByteOrder32Big,
 };
-use crate::frameworks::core_graphics::{CGPoint, CGRect, CGSize};
+use crate::frameworks::core_graphics::{CGFloat, CGPoint, CGRect, CGSize};
 use crate::frameworks::foundation::ns_string;
 use crate::mem::{GuestUSize, Ptr};
 use crate::objc::{id, msg, nil, objc_classes, release, retain, ClassExports, HostObject, ObjC};
 use std::collections::HashMap;
+use crate::frameworks::core_animation::ca_transform::CATransform3D;
 
 pub(super) struct CALayerHostObject {
     /// Possibly nil, usually a UIView. This is a weak reference.
@@ -32,12 +33,14 @@ pub(super) struct CALayerHostObject {
     superlayer: id,
     pub(super) bounds: CGRect,
     pub(super) position: CGPoint,
+    pub(super) zPosition: CGFloat,
     pub(super) anchor_point: CGPoint,
     pub(super) hidden: bool,
     pub(super) opaque: bool,
     pub(super) opacity: f32,
     pub(super) background_color: CGColorRef,
     pub(super) needs_display: bool,
+    pub(super) transform: CATransform3D,
     /// `CGImageRef*`
     pub(super) contents: id,
     /// For CAEAGLLayer only
@@ -85,12 +88,14 @@ pub const CLASSES: ClassExports = objc_classes! {
             size: CGSize { width: 0.0, height: 0.0 }
         },
         position: CGPoint { x: 0.0, y: 0.0 },
+        zPosition: 0.0,
         anchor_point: CGPoint { x: 0.5, y: 0.5 },
         hidden: false,
         opaque: false,
         opacity: 1.0,
         background_color: nil, // transparency
         needs_display: true,
+        transform: CATransform3D::identity(),
         contents: nil,
         drawable_properties: nil,
         presented_pixels: None,
@@ -194,11 +199,20 @@ pub const CLASSES: ClassExports = objc_classes! {
 - (())setBounds:(CGRect)bounds {
     env.objc.borrow_mut::<CALayerHostObject>(this).bounds = bounds;
 }
+- (())setMasksToBounds:(bool)masksToBounds {
+    log!("Ignoring [(CALayer*){:?} setMasksToBounds:{:?}]", this, masksToBounds);
+}
 - (CGPoint)position {
     env.objc.borrow::<CALayerHostObject>(this).position
 }
 - (())setPosition:(CGPoint)position {
     env.objc.borrow_mut::<CALayerHostObject>(this).position = position;
+}
+- (CGFloat)zPosition {
+    env.objc.borrow::<CALayerHostObject>(this).zPosition
+}
+- (())setZPosition:(CGFloat)zPosition {
+    env.objc.borrow_mut::<CALayerHostObject>(this).zPosition = zPosition;
 }
 - (CGPoint)anchorPoint {
     env.objc.borrow::<CALayerHostObject>(this).anchor_point
@@ -378,6 +392,15 @@ pub const CLASSES: ClassExports = objc_classes! {
     CGContextClearRect(env, cg_context, CGRect { origin, size });
     () = msg![env; delegate drawLayer:this inContext:cg_context];
     CGContextTranslateCTM(env, cg_context, origin.x, origin.y);
+}
+
+// CATransform3D
+- (CATransform3D)transform {
+    env.objc.borrow::<CALayerHostObject>(this).transform
+}
+
+- (())setTransform:(CATransform3D)new_transform {
+    env.objc.borrow_mut::<CALayerHostObject>(this).transform = new_transform;
 }
 
 // CGImageRef*

--- a/src/frameworks/core_animation/ca_media_timing_function.rs
+++ b/src/frameworks/core_animation/ca_media_timing_function.rs
@@ -49,6 +49,13 @@ pub const CLASSES: ClassExports = objc_classes! {
 
 @implementation CAMediaTimingFunction: NSObject
 
++ (id)functionWithControlPoints :(f32)_c1x _y:(f32)_c1y _x2:(f32)_c2x _y2:(f32)_c2y {
+    let object = msg![env; this alloc];
+    let object = msg![env; object init];
+    log!("TODO: [CAMediaTimingFunction functionWithControlPoints::::] -> {:?}", object);
+    autorelease(env, object)
+}
+
 + (id)functionWithName:(CAMediaTimingFunctionName)name {
     let object = msg![env; this alloc];
     let object = msg![env; object init];

--- a/src/frameworks/core_animation/ca_transform.rs
+++ b/src/frameworks/core_animation/ca_transform.rs
@@ -1,5 +1,5 @@
 use crate::abi::GuestArg;
-use crate::dyld::FunctionExports;
+use crate::dyld::{ConstantExports, FunctionExports, HostConstant};
 use crate::environment::Environment;
 use crate::frameworks::core_graphics::CGFloat;
 use crate::mem::SafeRead;
@@ -111,3 +111,13 @@ pub fn CATransform3DMakeScale(_env: &mut Environment, sx: CGFloat, sy: CGFloat, 
 pub const FUNCTIONS: FunctionExports = &[
     export_c_func!(CATransform3DMakeScale(_,_,_))
 ];
+
+
+pub const CONSTANTS: ConstantExports = &[(
+    "_CATransform3DIdentity",
+    HostConstant::Custom(|mem, _| {
+        mem.alloc_and_write(CATransform3D::identity())
+            .cast()
+            .cast_const()
+    }),
+)];

--- a/src/frameworks/core_animation/ca_transform.rs
+++ b/src/frameworks/core_animation/ca_transform.rs
@@ -1,0 +1,113 @@
+use crate::abi::GuestArg;
+use crate::dyld::FunctionExports;
+use crate::environment::Environment;
+use crate::frameworks::core_graphics::CGFloat;
+use crate::mem::SafeRead;
+use crate::objc::HostObject;
+use crate::{export_c_func, impl_GuestRet_for_large_struct};
+use std::ops::{Index, IndexMut};
+
+#[derive(Debug, Default, Copy, Clone)]
+pub struct CATransform3D {
+    pub m11: CGFloat,
+    pub m12: CGFloat,
+    pub m13: CGFloat,
+    pub m14: CGFloat,
+    pub m21: CGFloat,
+    pub m22: CGFloat,
+    pub m23: CGFloat,
+    pub m24: CGFloat,
+    pub m31: CGFloat,
+    pub m32: CGFloat,
+    pub m33: CGFloat,
+    pub m34: CGFloat,
+    pub m41: CGFloat,
+    pub m42: CGFloat,
+    pub m43: CGFloat,
+    pub m44: CGFloat,
+}
+
+impl Index<(usize, usize)> for CATransform3D {
+    type Output = CGFloat;
+
+    fn index(&self, index: (usize, usize)) -> &Self::Output {
+        match index {
+            (1, 1) => &self.m11,
+            (1, 2) => &self.m12,
+            (1, 3) => &self.m13,
+            (1, 4) => &self.m14,
+            (2, 1) => &self.m21,
+            (2, 2) => &self.m22,
+            (2, 3) => &self.m23,
+            (2, 4) => &self.m24,
+            (3, 1) => &self.m31,
+            (3, 2) => &self.m32,
+            (3, 3) => &self.m33,
+            (3, 4) => &self.m34,
+            (4, 1) => &self.m41,
+            (4, 2) => &self.m42,
+            (4, 3) => &self.m43,
+            (4, 4) => &self.m44,
+            _ => panic!("Invalid index")
+        }
+    }
+}
+impl IndexMut<(usize, usize)> for CATransform3D {
+    fn index_mut(&mut self, index: (usize, usize)) -> &mut Self::Output {
+        match index {
+            (1, 1) => &mut self.m11,
+            (1, 2) => &mut self.m12,
+            (1, 3) => &mut self.m13,
+            (1, 4) => &mut self.m14,
+            (2, 1) => &mut self.m21,
+            (2, 2) => &mut self.m22,
+            (2, 3) => &mut self.m23,
+            (2, 4) => &mut self.m24,
+            (3, 1) => &mut self.m31,
+            (3, 2) => &mut self.m32,
+            (3, 3) => &mut self.m33,
+            (3, 4) => &mut self.m34,
+            (4, 1) => &mut self.m41,
+            (4, 2) => &mut self.m42,
+            (4, 3) => &mut self.m43,
+            (4, 4) => &mut self.m44,
+            _ => panic!("Invalid index")
+        }
+    }
+}
+impl CATransform3D {
+    pub fn identity() -> Self {
+        let mut transform = CATransform3D::default();
+        transform[(1,1)] = 1.0;
+        transform[(2,2)] = 1.0;
+        transform[(3,3)] = 1.0;
+        transform[(4,4)] = 1.0;
+        transform
+    }
+}
+unsafe impl SafeRead for CATransform3D {}
+impl HostObject for CATransform3D {}
+impl_GuestRet_for_large_struct!(CATransform3D);
+impl GuestArg for CATransform3D {
+    // TODO figure out how to pass big structs as arguments in the ARMv6 calling convention
+    const REG_COUNT: usize = 0;
+
+    fn from_regs(_regs: &[u32]) -> Self {
+        CATransform3D::identity()
+    }
+
+    fn to_regs(self, _regs: &mut [u32]) {
+    }
+}
+pub fn CATransform3DMakeScale(_env: &mut Environment, sx: CGFloat, sy: CGFloat, sz: CGFloat) -> CATransform3D {
+    let mut transform = CATransform3D::default();
+    transform[(1,1)] = sx;
+    transform[(2,2)] = sy;
+    transform[(3,3)] = sz;
+    transform[(4,4)] = 1.0;
+    transform
+}
+
+pub const FUNCTIONS: FunctionExports = &[
+    export_c_func!(CATransform3DMakeScale(_,_,_))
+];

--- a/src/frameworks/core_foundation/cf_data.rs
+++ b/src/frameworks/core_foundation/cf_data.rs
@@ -14,7 +14,7 @@ use crate::dyld::FunctionExports;
 use crate::export_c_func;
 use crate::frameworks::foundation::{NSRange, NSUInteger};
 use crate::mem::{ConstPtr, ConstVoidPtr, MutPtr};
-use crate::objc::{id, msg, msg_class};
+use crate::objc::{msg, msg_class};
 use crate::Environment;
 
 pub type CFDataRef = super::CFTypeRef;
@@ -28,8 +28,7 @@ pub fn CFDataCreate(
     assert!(allocator == kCFAllocatorDefault); // unimplemented
     let bytes: ConstVoidPtr = bytes.cast();
     let length: NSUInteger = length.try_into().unwrap();
-    let new: id = msg_class![env; NSData alloc];
-    msg![env; new dataWithBytes:bytes length:length]
+    msg_class![env; NSData dataWithBytes:bytes length:length]
 }
 
 fn CFDataGetLength(env: &mut Environment, data: CFDataRef) -> CFIndex {

--- a/src/frameworks/core_foundation/cf_run_loop_timer.rs
+++ b/src/frameworks/core_foundation/cf_run_loop_timer.rs
@@ -50,18 +50,25 @@ fn CFRunLoopTimerCreate(
     assert_eq!(flags, 0);
     assert_eq!(order, 0);
 
-    let context = env.mem.read(context_ptr);
-    let version = context.version;
-    assert_eq!(version, 0);
-    let info: MutVoidPtr = context.info;
+    // According to Apple docs (and at least one game) context_ptr can be null if context.info
+    // is not used by the application.
+    let info = if !context_ptr.is_null() {
+        let context = env.mem.read(context_ptr);
+        let version = context.version;
+        assert_eq!(version, 0);
 
-    // TODO: handle non-NULL callbacks
-    let retain_callback = context.release_callback;
-    assert!(retain_callback.to_ptr().is_null());
-    let release_callback = context.release_callback;
-    assert!(release_callback.to_ptr().is_null());
-    let copy_desc_callback = context.copy_desc_callback;
-    assert!(copy_desc_callback.to_ptr().is_null());
+        // TODO: handle non-NULL callbacks
+        let retain_callback = context.release_callback;
+        assert!(retain_callback.to_ptr().is_null());
+        let release_callback = context.release_callback;
+        assert!(release_callback.to_ptr().is_null());
+        let copy_desc_callback = context.copy_desc_callback;
+        assert!(copy_desc_callback.to_ptr().is_null());
+
+        context.info
+    } else {
+        MutVoidPtr::null()
+    };
 
     let target: id = msg_class![env; _touchHLE_CFTimerTarget alloc];
     let target: id = msg![env; target initWithCallout:callout info:info];

--- a/src/frameworks/core_graphics.rs
+++ b/src/frameworks/core_graphics.rs
@@ -16,6 +16,7 @@ pub mod cg_context;
 pub mod cg_data_provider;
 pub mod cg_geometry;
 pub mod cg_image;
+pub mod cg_font;
 
 pub type CGFloat = f32;
 

--- a/src/frameworks/core_graphics/cg_bitmap_context.rs
+++ b/src/frameworks/core_graphics/cg_bitmap_context.rs
@@ -9,7 +9,7 @@ use super::cg_affine_transform::{CGAffineTransform, CGAffineTransformIdentity};
 use super::cg_color_space::{
     kCGColorSpaceGenericGray, kCGColorSpaceGenericRGB, CGColorSpaceHostObject, CGColorSpaceRef,
 };
-use super::cg_context::{CGContextHostObject, CGContextRef, CGContextSubclass};
+use super::cg_context::{CGContextHostObject, CGContextRef, CGContextState, CGContextSubclass};
 use super::cg_image::{
     self, kCGBitmapAlphaInfoMask, kCGBitmapByteOrderMask, kCGImageAlphaFirst, kCGImageAlphaLast,
     kCGImageAlphaNone, kCGImageAlphaNoneSkipFirst, kCGImageAlphaNoneSkipLast, kCGImageAlphaOnly,
@@ -20,8 +20,9 @@ use super::{CGFloat, CGPoint, CGRect};
 use crate::dyld::{export_c_func, FunctionExports};
 use crate::image::{gamma_decode, gamma_encode, Image};
 use crate::mem::{GuestUSize, Mem, MutVoidPtr};
-use crate::objc::ObjC;
+use crate::objc::{nil, ObjC};
 use crate::Environment;
+use crate::frameworks::core_graphics::cg_geometry::CGSizeZero;
 
 #[derive(Copy, Clone)]
 pub(super) struct CGBitmapContextData {
@@ -81,9 +82,20 @@ pub fn CGBitmapContextCreate(
             alpha_info: bitmap_info & kCGBitmapAlphaInfoMask,
         }),
         // TODO: is this the correct default?
-        rgb_fill_color: (0.0, 0.0, 0.0, 0.0),
-        transform: CGAffineTransformIdentity,
+        state: CGContextState {
+            rgb_fill_color: (0.0, 0.0, 0.0, 0.0),
+            rgb_stroke_color: (0.0, 0.0, 0.0, 0.0),
+            transform: CGAffineTransformIdentity,
+            line_width: 1.0,
+            text_font: nil,
+            font_size: 1.0,
+            text_drawing_mode: 0,
+            shadow_blur: 0.0,
+            shadow_color: nil,
+            shadow_offset: CGSizeZero,
+        },
         state_stack: Vec::new(),
+        text_matrix: CGAffineTransformIdentity,
     };
     let isa = env
         .objc
@@ -133,7 +145,7 @@ pub fn CGBitmapContextCreateImage(env: &mut Environment, context: CGContextRef) 
         .to_vec();
     cg_image::from_image(
         env,
-        Image::from_pixel_vec(pixels, (bitmap_data.width, bitmap_data.height)),
+        Image::from_pixel_vec(pixels, (bitmap_data.width, bitmap_data.height), 4),
     )
 }
 
@@ -356,6 +368,7 @@ pub struct CGBitmapContextDrawer<'a> {
     bitmap_info: CGBitmapContextData,
     rgb_fill_color: (CGFloat, CGFloat, CGFloat, CGFloat),
     transform: CGAffineTransform,
+    line_width: CGFloat,
     pixels: &'a mut [u8],
 }
 impl CGBitmapContextDrawer<'_> {
@@ -366,9 +379,19 @@ impl CGBitmapContextDrawer<'_> {
     ) -> CGBitmapContextDrawer<'a> {
         let &CGContextHostObject {
             subclass: CGContextSubclass::CGBitmapContext(bitmap_info),
-            rgb_fill_color,
-            transform,
-            ..
+            state: CGContextState {
+                rgb_fill_color,
+                rgb_stroke_color: _,
+                transform,
+                line_width,
+                font_size: _,
+                text_font: _,
+                text_drawing_mode: _,
+                shadow_offset: _,
+                shadow_color: _,
+                shadow_blur: _,
+            },
+        ..
         } = objc.borrow(context);
 
         let pixels = get_pixels(&bitmap_info, mem);
@@ -377,6 +400,7 @@ impl CGBitmapContextDrawer<'_> {
             bitmap_info,
             rgb_fill_color,
             transform,
+            line_width,
             pixels,
         }
     }
@@ -484,6 +508,7 @@ fn test_iter_transformed_pixels() {
             },
             rgb_fill_color: (0.0, 0.0, 0.0, 0.0),
             transform,
+            line_width: 1.0,
             pixels: &mut [],
         }
     }

--- a/src/frameworks/core_graphics/cg_context.rs
+++ b/src/frameworks/core_graphics/cg_context.rs
@@ -5,6 +5,7 @@
  */
 //! `CGContext.h`
 
+use owned_ttf_parser::GlyphId;
 use super::cg_affine_transform::CGAffineTransform;
 use super::cg_image::CGImageRef;
 use super::{cg_bitmap_context, CGFloat, CGPoint, CGRect, CGSize};
@@ -256,10 +257,11 @@ pub fn CGContextSetShadowWithColor(env: &mut Environment, context: CGContextRef,
 
 pub fn CGContextShowGlyphsAtPoint(env: &mut Environment, context: CGContextRef, x: CGFloat, y: CGFloat, glyphs: ConstPtr<CGGlyph>, count: GuestUSize) {
     let context = env.objc.borrow::<CGContextHostObject>(context);
-    let glyphs = (0..count).map(|i| (glyphs+i, env.mem.read(glyphs+i))).collect::<Vec<(ConstPtr<CGGlyph>, CGGlyph)>>();
-    let glyphs = glyphs.iter().map(|(_, glyph)| *(glyph) as u8 as char).collect::<Vec<char>>();
-    let text: String = glyphs.into_iter().collect();
-    glyphs_at_point(env, context.state.text_font, &text, CGPoint {
+    let glyphs = (0..count)
+        .map(|i| env.mem.read(glyphs+i))
+        .map(|g| GlyphId(g))
+        .collect::<Vec<_>>();
+    glyphs_at_point(env, context.state.text_font, &glyphs, CGPoint {
         x, y
     })
 }

--- a/src/frameworks/core_graphics/cg_context.rs
+++ b/src/frameworks/core_graphics/cg_context.rs
@@ -7,13 +7,18 @@
 
 use super::cg_affine_transform::CGAffineTransform;
 use super::cg_image::CGImageRef;
-use super::{cg_bitmap_context, CGFloat, CGRect};
+use super::{cg_bitmap_context, CGFloat, CGPoint, CGRect, CGSize};
 use crate::dyld::{export_c_func, FunctionExports};
 use crate::frameworks::core_foundation::{CFRelease, CFRetain, CFTypeRef};
 use crate::objc::{objc_classes, ClassExports, HostObject};
 use crate::Environment;
+use crate::frameworks::core_graphics::cg_color::CGColorRef;
+use crate::frameworks::core_graphics::cg_font::{glyphs_at_point, CGFontRef, CGGlyph};
+use crate::mem::{ConstPtr, GuestUSize};
 
 type CGInterpolationQuality = i32;
+pub type CGTextDrawingMode = i32;
+// TODO: find constant values for this enum
 
 pub const CLASSES: ClassExports = objc_classes! {
 
@@ -38,13 +43,28 @@ pub const CLASSES: ClassExports = objc_classes! {
 
 };
 
-pub(super) struct CGContextHostObject {
-    pub(super) subclass: CGContextSubclass,
+#[derive(Copy, Clone)]
+pub(super) struct CGContextState {
     pub(super) rgb_fill_color: (CGFloat, CGFloat, CGFloat, CGFloat),
+    pub(super) rgb_stroke_color: (CGFloat, CGFloat, CGFloat, CGFloat),
+    pub(super) line_width: CGFloat,
     /// Current transform.
     pub(super) transform: CGAffineTransform,
+    pub(super) font_size: CGFloat,
+    pub(super) text_font: CGFontRef,
+    pub(super) text_drawing_mode: CGTextDrawingMode,
+    pub(super) shadow_offset: CGSize,
+    pub(super) shadow_blur: CGFloat,
+    pub(super) shadow_color: CGColorRef,
+}
+
+pub(super) struct CGContextHostObject {
+    pub(super) subclass: CGContextSubclass,
+    pub(super) state: CGContextState,
     // TODO: keep more states saved once they are implemented
-    pub(super) state_stack: Vec<((CGFloat, CGFloat, CGFloat, CGFloat), CGAffineTransform)>,
+    pub(super) state_stack: Vec<CGContextState>,
+    // TODO: according to documentation these aren't part of state and aren't affected by pop/push, check if true?
+    pub(super) text_matrix: CGAffineTransform,
 }
 impl HostObject for CGContextHostObject {}
 
@@ -67,6 +87,32 @@ pub fn CGContextRetain(env: &mut Environment, c: CGContextRef) -> CGContextRef {
     }
 }
 
+pub fn CGContextSetLineWidth(
+    env: &mut Environment,
+    context: CGContextRef,
+    line_width: CGFloat,
+) {
+    env.objc
+        .borrow_mut::<CGContextHostObject>(context)
+        .state
+        .line_width = line_width;
+}
+
+pub fn CGContextSetRGBStrokeColor(
+    env: &mut Environment,
+    context: CGContextRef,
+    red: CGFloat,
+    green: CGFloat,
+    blue: CGFloat,
+    alpha: CGFloat,
+) {
+    let color = (red, green, blue, alpha);
+    env.objc
+        .borrow_mut::<CGContextHostObject>(context)
+        .state
+        .rgb_stroke_color = color;
+}
+
 pub fn CGContextSetRGBFillColor(
     env: &mut Environment,
     context: CGContextRef,
@@ -78,6 +124,7 @@ pub fn CGContextSetRGBFillColor(
     let color = (red, green, blue, alpha);
     env.objc
         .borrow_mut::<CGContextHostObject>(context)
+        .state
         .rgb_fill_color = color;
 }
 
@@ -90,6 +137,7 @@ fn CGContextSetGrayFillColor(
     let color = (gray, gray, gray, alpha);
     env.objc
         .borrow_mut::<CGContextHostObject>(context)
+        .state
         .rgb_fill_color = color;
 }
 
@@ -108,22 +156,22 @@ pub fn CGContextConcatCTM(
 ) {
     log_dbg!("CGContextConcatCTM({:?})", transform);
     let host_obj = env.objc.borrow_mut::<CGContextHostObject>(context);
-    host_obj.transform = transform.concat(host_obj.transform);
+    host_obj.state.transform = transform.concat(host_obj.state.transform);
 }
 pub fn CGContextGetCTM(env: &mut Environment, context: CGContextRef) -> CGAffineTransform {
-    let res = env.objc.borrow::<CGContextHostObject>(context).transform;
+    let res = env.objc.borrow::<CGContextHostObject>(context).state.transform;
     log_dbg!("CGContextGetCTM() => {:?}", res);
     res
 }
 pub fn CGContextRotateCTM(env: &mut Environment, context: CGContextRef, angle: CGFloat) {
     log_dbg!("CGContextRotateCTM({:?})", angle);
     let host_obj = env.objc.borrow_mut::<CGContextHostObject>(context);
-    host_obj.transform = host_obj.transform.rotate(angle);
+    host_obj.state.transform = host_obj.state.transform.rotate(angle);
 }
 pub fn CGContextScaleCTM(env: &mut Environment, context: CGContextRef, x: CGFloat, y: CGFloat) {
     log_dbg!("CGContextScaleCTM({:?})", (x, y));
     let host_obj = env.objc.borrow_mut::<CGContextHostObject>(context);
-    host_obj.transform = host_obj.transform.scale(x, y);
+    host_obj.state.transform = host_obj.state.transform.scale(x, y);
 }
 pub fn CGContextTranslateCTM(
     env: &mut Environment,
@@ -133,7 +181,7 @@ pub fn CGContextTranslateCTM(
 ) {
     log_dbg!("CGContextTranslateCTM({:?})", (tx, ty));
     let host_obj = env.objc.borrow_mut::<CGContextHostObject>(context);
-    host_obj.transform = host_obj.transform.translate(tx, ty);
+    host_obj.state.transform = host_obj.state.transform.translate(tx, ty);
 }
 
 pub fn CGContextDrawImage(
@@ -149,14 +197,13 @@ fn CGContextSaveGState(env: &mut Environment, context: CGContextRef) {
     let host_obj = env.objc.borrow_mut::<CGContextHostObject>(context);
     host_obj
         .state_stack
-        .push((host_obj.rgb_fill_color, host_obj.transform));
+        .push(host_obj.state);
 }
 
 fn CGContextRestoreGState(env: &mut Environment, context: CGContextRef) {
     let host_obj = env.objc.borrow_mut::<CGContextHostObject>(context);
     let state = host_obj.state_stack.pop().unwrap();
-    host_obj.rgb_fill_color = state.0;
-    host_obj.transform = state.1;
+    host_obj.state = state;
 }
 
 fn CGContextSetInterpolationQuality(
@@ -171,10 +218,58 @@ fn CGContextSetInterpolationQuality(
     );
 }
 
+pub fn CGContextGetClipBoundingBox(
+    _env: &mut Environment,
+    _context: CGContextRef,
+) -> CGRect {
+    CGRect::default()
+}
+
+pub fn CGContextClipToRect(
+    _env: &mut Environment,
+    _context: CGContextRef,
+    _rect: CGRect
+) {
+}
+
+pub fn CGContextSetTextMatrix(env: &mut Environment, context: CGContextRef, matrix: CGAffineTransform) {
+    env.objc.borrow_mut::<CGContextHostObject>(context).text_matrix = matrix;
+}
+
+pub fn CGContextSetFont(env: &mut Environment, context: CGContextRef, font: CGFontRef) {
+    env.objc.borrow_mut::<CGContextHostObject>(context).state.text_font = font;
+}
+
+pub fn CGContextSetFontSize(env: &mut Environment, context: CGContextRef, font_size: CGFloat) {
+    env.objc.borrow_mut::<CGContextHostObject>(context).state.font_size = font_size;
+}
+
+pub fn CGContextSetTextDrawingMode(env: &mut Environment, context: CGContextRef, mode: CGTextDrawingMode) {
+    env.objc.borrow_mut::<CGContextHostObject>(context).state.text_drawing_mode = mode;
+}
+
+pub fn CGContextSetShadowWithColor(env: &mut Environment, context: CGContextRef, offset: CGSize, blur: CGFloat, color: CGColorRef) {
+    env.objc.borrow_mut::<CGContextHostObject>(context).state.shadow_offset = offset;
+    env.objc.borrow_mut::<CGContextHostObject>(context).state.shadow_blur = blur;
+    env.objc.borrow_mut::<CGContextHostObject>(context).state.shadow_color = color;
+}
+
+pub fn CGContextShowGlyphsAtPoint(env: &mut Environment, context: CGContextRef, x: CGFloat, y: CGFloat, glyphs: ConstPtr<CGGlyph>, count: GuestUSize) {
+    let context = env.objc.borrow::<CGContextHostObject>(context);
+    let glyphs = (0..count).map(|i| (glyphs+i, env.mem.read(glyphs+i))).collect::<Vec<(ConstPtr<CGGlyph>, CGGlyph)>>();
+    let glyphs = glyphs.iter().map(|(_, glyph)| *(glyph) as u8 as char).collect::<Vec<char>>();
+    let text: String = glyphs.into_iter().collect();
+    glyphs_at_point(env, context.state.text_font, &text, CGPoint {
+        x, y
+    })
+}
+
 pub const FUNCTIONS: FunctionExports = &[
     export_c_func!(CGContextRetain(_)),
     export_c_func!(CGContextRelease(_)),
+    export_c_func!(CGContextSetLineWidth(_, _)),
     export_c_func!(CGContextSetRGBFillColor(_, _, _, _, _)),
+    export_c_func!(CGContextSetRGBStrokeColor(_, _, _, _, _)),
     export_c_func!(CGContextSetGrayFillColor(_, _, _)),
     export_c_func!(CGContextFillRect(_, _)),
     export_c_func!(CGContextClearRect(_, _)),
@@ -187,4 +282,12 @@ pub const FUNCTIONS: FunctionExports = &[
     export_c_func!(CGContextSaveGState(_)),
     export_c_func!(CGContextRestoreGState(_)),
     export_c_func!(CGContextSetInterpolationQuality(_, _)),
+    export_c_func!(CGContextGetClipBoundingBox(_)),
+    export_c_func!(CGContextClipToRect(_, _)),
+    export_c_func!(CGContextSetTextMatrix(_, _)),
+    export_c_func!(CGContextSetFont(_, _)),
+    export_c_func!(CGContextSetFontSize(_, _)),
+    export_c_func!(CGContextSetTextDrawingMode(_, _)),
+    export_c_func!(CGContextSetShadowWithColor(_, _, _, _)),
+    export_c_func!(CGContextShowGlyphsAtPoint(_, _, _, _, _)),
 ];

--- a/src/frameworks/core_graphics/cg_data_provider.rs
+++ b/src/frameworks/core_graphics/cg_data_provider.rs
@@ -13,7 +13,7 @@ use crate::frameworks::core_foundation::cf_allocator::kCFAllocatorDefault;
 use crate::frameworks::core_foundation::cf_data::{CFDataCreate, CFDataRef};
 use crate::frameworks::core_foundation::{CFRelease, CFRetain, CFTypeRef};
 use crate::frameworks::foundation::NSUInteger;
-use crate::mem::{ConstVoidPtr, GuestUSize, MutVoidPtr};
+use crate::mem::{ConstPtr, ConstVoidPtr, GuestUSize, MutVoidPtr};
 use crate::objc::{id, msg, msg_class, objc_classes, ClassExports, HostObject};
 use crate::Environment;
 
@@ -88,6 +88,23 @@ pub fn CGDataProviderRetain(env: &mut Environment, c: CGDataProviderRef) -> CGDa
     } else {
         c
     }
+}
+
+fn CGDataProviderCreateWithFilename(
+    env: &mut Environment,
+    filename: ConstPtr<u8>,
+) -> CGDataProviderRef {
+    let filename: id = msg_class![env; NSString stringWithCString:filename];
+    let ns_data: id = msg_class![env; NSData dataWithContentsOfFile:filename];
+    let bytes: ConstVoidPtr = msg![env; ns_data bytes];
+    let length: NSUInteger = msg![env; ns_data length];
+    CGDataProviderCreateWithData(
+        env,
+        MutVoidPtr::null(),
+        bytes,
+        length,
+        CGDataProviderReleaseDataCallback::null_ptr(),
+    )
 }
 
 fn CGDataProviderCreateWithData(
@@ -166,6 +183,7 @@ fn CGDataProviderCopyData(env: &mut Environment, provider: CGDataProviderRef) ->
 pub const FUNCTIONS: FunctionExports = &[
     export_c_func!(CGDataProviderRetain(_)),
     export_c_func!(CGDataProviderRelease(_)),
+    export_c_func!(CGDataProviderCreateWithFilename(_)),
     export_c_func!(CGDataProviderCreateWithData(_, _, _, _)),
     export_c_func!(CGDataProviderCopyData(_)),
 ];

--- a/src/frameworks/core_graphics/cg_font.rs
+++ b/src/frameworks/core_graphics/cg_font.rs
@@ -125,7 +125,7 @@ pub const CLASSES: ClassExports = objc_classes! {
 pub fn glyphs_at_point(
     env: &mut Environment,
     font: id,
-    text: &str,
+    glyphs: &[GlyphId],
     point: CGPoint,
 ) {
     let context = UIGraphicsGetCurrentContext(env);
@@ -138,9 +138,9 @@ pub fn glyphs_at_point(
     let mut drawer = CGBitmapContextDrawer::new(&env.objc, &mut env.mem, context);
     let fill_color = drawer.rgb_fill_color();
 
-    font.draw(
-        context_host.state.font_size * 0.45,
-        text,
+    font.draw_glyphs(
+        context_host.state.font_size * 0.5,
+        glyphs,
         (point.x, point.y),
         None,
         TextAlignment::Left,
@@ -177,7 +177,7 @@ pub fn CGFontCreateWithDataProvider(env: &mut Environment, provider: CGDataProvi
 
 pub fn CGFontCopyTableForTag(env: &mut Environment, font: CGFontRef, tag: u32) -> CFDataRef {
     let font = env.objc.borrow::<CGFontHostObject>(font);
-    let table_bytes = CMap::serialize(&CMap::table_from_font(&font.font));
+    let table_bytes = font.font.get_raw_table(tag);
     let table_bytes_guest = env.mem.alloc(table_bytes.len() as GuestUSize).cast();
     for i in 0..table_bytes.len() {
         env.mem.write::<u8>(table_bytes_guest + i as GuestUSize, table_bytes[i]);

--- a/src/frameworks/core_graphics/cg_font.rs
+++ b/src/frameworks/core_graphics/cg_font.rs
@@ -1,0 +1,166 @@
+use owned_ttf_parser::GlyphId;
+use crate::dyld::FunctionExports;
+use crate::environment::Environment;
+use crate::frameworks::core_foundation::cf_string::CFStringRef;
+use crate::frameworks::core_foundation::{CFIndex, CFTypeRef};
+use crate::objc::{id, ClassExports, HostObject};
+use crate::{export_c_func, objc_classes};
+use crate::font::{Font, TextAlignment};
+use crate::frameworks::core_foundation::cf_allocator::kCFAllocatorDefault;
+use crate::frameworks::core_foundation::cf_data::{CFDataCreate, CFDataRef};
+use crate::frameworks::core_graphics::cg_data_provider::CGDataProviderRef;
+use crate::frameworks::core_graphics::{CGPoint, CGRect, CGSize};
+use crate::frameworks::core_graphics::cg_bitmap_context::CGBitmapContextDrawer;
+use crate::frameworks::core_graphics::cg_context::CGContextHostObject;
+use crate::frameworks::foundation::ns_string::{from_rust_string, to_rust_string};
+use crate::frameworks::uikit::ui_graphics::UIGraphicsGetCurrentContext;
+use crate::mem::{ConstPtr, GuestUSize, MutPtr};
+
+pub type CGFontRef = CFTypeRef;
+pub struct CGFontHostObject {
+    font: Font,
+}
+impl HostObject for CGFontHostObject {}
+pub type CGFontIndex = u16;
+pub type CGGlyph = CGFontIndex;
+pub const CLASSES: ClassExports = objc_classes! {
+
+(env, this, _cmd);
+
+@implementation CGFont: NSObject
+@end
+
+};
+
+/// Called by `crate::frameworks::core_graphics::cg_context::CGContextShowGlyphsAtPoint`.
+pub fn glyphs_at_point(
+    env: &mut Environment,
+    font: id,
+    text: &str,
+    point: CGPoint,
+) {
+    let context = UIGraphicsGetCurrentContext(env);
+
+    let host_object = env.objc.borrow::<CGFontHostObject>(font);
+
+    let font = &host_object.font;
+    let context_host = env.objc.borrow::<CGContextHostObject>(context);
+
+    let mut drawer = CGBitmapContextDrawer::new(&env.objc, &mut env.mem, context);
+    let fill_color = drawer.rgb_fill_color();
+
+    font.draw(
+        context_host.state.font_size * 0.45,
+        text,
+        (point.x, point.y),
+        None,
+        TextAlignment::Left,
+        |raster_glyph| {
+            crate::frameworks::uikit::ui_font::draw_font_glyph(
+                &mut drawer,
+                raster_glyph,
+                fill_color,
+                /* clip_x: */ None,
+                /* clip_y: */ None,
+            )
+        },
+    );
+}
+
+pub fn CGFontCreateWithFontName(env: &mut Environment, name: CFStringRef) -> CGFontRef {
+    let host_obj = Box::new(CGFontHostObject {
+        font: Font::serif_regular() // TODO actually load requested font.
+    });
+    let name = to_rust_string(env, name);
+    log!("Ignoring CGFontCreateWithFontName((CFString*){:?})", name);
+    let class = env.objc.get_known_class("CGFont", &mut env.mem);
+    env.objc.alloc_object(class, host_obj, &mut env.mem)
+}
+
+pub fn CGFontCreateWithDataProvider(env: &mut Environment, provider: CGDataProviderRef) -> CGFontRef {
+    log!("Ignoring CGFontCreateWithDataProvider((CGDataProvider*){:?})", provider);
+    let host_obj = Box::new(CGFontHostObject {
+        font: Font::serif_regular() // TODO actually load requested font.
+    });
+    let class = env.objc.get_known_class("CGFont", &mut env.mem);
+    env.objc.alloc_object(class, host_obj, &mut env.mem)
+}
+
+pub fn CGFontCopyTableForTag(env: &mut Environment, font: CGFontRef, tag: u32) -> CFDataRef {
+    let font = env.objc.borrow::<CGFontHostObject>(font);
+    let table_bytes = font.font.get_raw_table(tag);
+    let table_bytes_guest = env.mem.alloc(table_bytes.len() as GuestUSize).cast();
+    for i in 0..table_bytes.len() {
+        env.mem.write::<u8>(table_bytes_guest + i as GuestUSize, table_bytes[i]);
+    }
+    CFDataCreate(env, kCFAllocatorDefault, table_bytes_guest.cast_const(), table_bytes.len() as CFIndex)
+}
+
+pub fn CGFontCopyFullName(env: &mut Environment, font: CGFontRef) -> CFStringRef {
+    let font = env.objc.borrow::<CGFontHostObject>(font);
+    from_rust_string(env, font.font.name())
+}
+
+pub fn CGFontGetGlyphBBoxes(env: &mut Environment, font: CGFontRef, glyphs: ConstPtr<CGGlyph>, count: GuestUSize, bboxes: MutPtr<CGRect>) -> bool {
+    let font = env.objc.borrow::<CGFontHostObject>(font);
+    let mut point = CGPoint {
+        x: 0.0,
+        y: 0.0,
+    };
+
+    for (x, i) in (1..count).map(|i| (glyphs + i, i)).map(|(ptr, i)| (env.mem.read(ptr), i)).collect::<Vec<_>>() {
+        let bbox = font.font.glyph_size(GlyphId(x as u16));
+        let width = bbox.width() as f32;
+        let height = bbox.height() as f32;
+        let rect = CGRect {
+            origin: point,
+            size: CGSize {
+                width,
+                height,
+            }
+        };
+        env.mem.write(bboxes + i, rect);
+        point.x += width;
+    }
+    true
+}
+
+pub fn CGFontGetGlyphAdvances(env: &mut Environment, font: CGFontRef, glyphs: ConstPtr<CGGlyph>, count: GuestUSize, advances: MutPtr<i32>) -> bool {
+    let font = env.objc.borrow::<CGFontHostObject>(font);
+    for (x, i) in (1..count).map(|i| (glyphs + i, i)).map(|(ptr, i)| (env.mem.read(ptr), i)).collect::<Vec<_>>() {
+        env.mem.write(advances + i, font.font.advance_unscaled(x));
+    }
+    true
+}
+
+pub fn CGFontGetAscent(env: &mut Environment, font: CGFontRef) -> i32 {
+    let font = env.objc.borrow::<CGFontHostObject>(font);
+    font.font.ascent_unscaled()
+}
+
+pub fn CGFontGetDescent(env: &mut Environment, font: CGFontRef) -> i32 {
+    let font = env.objc.borrow::<CGFontHostObject>(font);
+    font.font.descent_unscaled()
+}
+pub fn CGFontGetCapHeight(env: &mut Environment, font: CGFontRef) -> i32 {
+    let font = env.objc.borrow::<CGFontHostObject>(font);
+    font.font.cap_height()
+}
+
+pub fn CGFontGetUnitsPerEm(env: &mut Environment, font: CGFontRef) -> i32 {
+    let font = env.objc.borrow::<CGFontHostObject>(font);
+    font.font.units_per_em() as i32
+}
+
+pub const FUNCTIONS: FunctionExports = &[
+    export_c_func!(CGFontCopyFullName(_)),
+    export_c_func!(CGFontCreateWithFontName(_)),
+    export_c_func!(CGFontCreateWithDataProvider(_)),
+    export_c_func!(CGFontCopyTableForTag(_, _)),
+    export_c_func!(CGFontGetGlyphBBoxes(_, _, _, _)),
+    export_c_func!(CGFontGetGlyphAdvances(_, _, _, _)),
+    export_c_func!(CGFontGetAscent(_)),
+    export_c_func!(CGFontGetDescent(_)),
+    export_c_func!(CGFontGetUnitsPerEm(_)),
+    export_c_func!(CGFontGetCapHeight(_)),
+];

--- a/src/frameworks/core_graphics/cg_font.rs
+++ b/src/frameworks/core_graphics/cg_font.rs
@@ -15,7 +15,96 @@ use crate::frameworks::core_graphics::cg_context::CGContextHostObject;
 use crate::frameworks::foundation::ns_string::{from_rust_string, to_rust_string};
 use crate::frameworks::uikit::ui_graphics::UIGraphicsGetCurrentContext;
 use crate::mem::{ConstPtr, GuestUSize, MutPtr};
+pub mod CMap {
+    use symphonia::core::meta::StandardTagKey::EncodedBy;
+    use crate::font::Font;
 
+    #[derive(Clone)]
+    pub struct Table {
+        pub version: u16,
+        pub subtable_count: u16,
+        pub encoding_records: Vec<EncodingRecord>,
+        pub subtables: Vec<Subtable>,
+    }
+
+    #[derive(Clone)]
+    pub struct EncodingRecord {
+        pub platform_id: u16,
+        pub platform_specific_id: u16,
+        pub offset: u32,
+    }
+
+    #[derive(Clone)]
+    pub struct SubtableFormat6 {
+        pub format: u16,
+        pub length: u16,
+        pub language: u16,
+        pub first_code: u16,
+        pub entry_count: u16,
+        pub glyph_index_array: Vec<u16>,
+    }
+
+    #[derive(Clone)]
+    pub enum Subtable {
+        Format6(SubtableFormat6)
+    }
+
+    pub fn table_from_font(_font: &Font) -> Table {
+        let ascii_range = (0u8..255u8);
+        let codepoints: Vec<u16> = ascii_range
+            .map(|cp| cp as u16)
+            .collect();
+        Table {
+            version: 0,
+            subtable_count: 1,
+            encoding_records: [
+                EncodingRecord {
+                    platform_id: 0,
+                    platform_specific_id: 3,
+                    offset: (size_of::<u16>()*2 + size_of::<EncodingRecord>()) as u32
+                }
+            ].to_vec(),
+            subtables: [
+                Subtable::Format6(
+                    SubtableFormat6{
+                        format: 6,
+                        length: 256*2,
+                        language: 0,
+                        first_code: 0,
+                        entry_count: codepoints.len() as u16,
+                        glyph_index_array: codepoints
+                    }
+                )
+            ].to_vec()
+        }
+    }
+
+    pub fn serialize(table: &Table) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&table.version.to_be_bytes());
+        buf.extend_from_slice(&table.subtable_count.to_be_bytes());
+        for record in table.encoding_records.iter() {
+            buf.extend_from_slice(&record.platform_id.to_be_bytes());
+            buf.extend_from_slice(&record.platform_specific_id.to_be_bytes());
+            buf.extend_from_slice(&record.offset.to_be_bytes());
+        }
+        for subtable in table.subtables.iter() {
+            match subtable {
+                Subtable::Format6(format6) => {
+                    buf.extend_from_slice(&format6.format.to_be_bytes());
+                    buf.extend_from_slice(&format6.length.to_be_bytes());
+                    buf.extend_from_slice(&format6.language.to_be_bytes());
+                    buf.extend_from_slice(&format6.first_code.to_be_bytes());
+                    buf.extend_from_slice(&format6.entry_count.to_be_bytes());
+                    for &glyph_id in &format6.glyph_index_array {
+                        buf.extend_from_slice(&glyph_id.to_be_bytes());
+                    }
+                }
+            }
+        }
+        buf
+    }
+}
 pub type CGFontRef = CFTypeRef;
 pub struct CGFontHostObject {
     font: Font,
@@ -69,7 +158,7 @@ pub fn glyphs_at_point(
 
 pub fn CGFontCreateWithFontName(env: &mut Environment, name: CFStringRef) -> CGFontRef {
     let host_obj = Box::new(CGFontHostObject {
-        font: Font::serif_regular() // TODO actually load requested font.
+        font: Font::sans_regular() // TODO actually load requested font.
     });
     let name = to_rust_string(env, name);
     log!("Ignoring CGFontCreateWithFontName((CFString*){:?})", name);
@@ -80,7 +169,7 @@ pub fn CGFontCreateWithFontName(env: &mut Environment, name: CFStringRef) -> CGF
 pub fn CGFontCreateWithDataProvider(env: &mut Environment, provider: CGDataProviderRef) -> CGFontRef {
     log!("Ignoring CGFontCreateWithDataProvider((CGDataProvider*){:?})", provider);
     let host_obj = Box::new(CGFontHostObject {
-        font: Font::serif_regular() // TODO actually load requested font.
+        font: Font::sans_regular() // TODO actually load requested font.
     });
     let class = env.objc.get_known_class("CGFont", &mut env.mem);
     env.objc.alloc_object(class, host_obj, &mut env.mem)
@@ -88,7 +177,7 @@ pub fn CGFontCreateWithDataProvider(env: &mut Environment, provider: CGDataProvi
 
 pub fn CGFontCopyTableForTag(env: &mut Environment, font: CGFontRef, tag: u32) -> CFDataRef {
     let font = env.objc.borrow::<CGFontHostObject>(font);
-    let table_bytes = font.font.get_raw_table(tag);
+    let table_bytes = CMap::serialize(&CMap::table_from_font(&font.font));
     let table_bytes_guest = env.mem.alloc(table_bytes.len() as GuestUSize).cast();
     for i in 0..table_bytes.len() {
         env.mem.write::<u8>(table_bytes_guest + i as GuestUSize, table_bytes[i]);

--- a/src/frameworks/core_graphics/cg_image.rs
+++ b/src/frameworks/core_graphics/cg_image.rs
@@ -42,6 +42,9 @@ pub const kCGBitmapAlphaInfoMask: CGBitmapInfo = 0x1F; // huh, it's not 0x7?
 pub const kCGBitmapByteOrderMask: CGBitmapInfo = kCGImageByteOrderMask;
 // TODO: other stuff in this enum (for now, always assert the rest is 0)
 
+pub type CGColorRenderingIntent = i32;
+// TODO figure out values for this enum
+
 pub const CLASSES: ClassExports = objc_classes! {
 
 (env, this, _cmd);
@@ -95,12 +98,47 @@ pub fn borrow_image_mut(objc: &mut ObjC, image: CGImageRef) -> &mut Image {
 
 // TODO: More create methods.
 
+fn CGImageCreate(
+    env: &mut Environment,
+    width: GuestUSize,
+    height: GuestUSize,
+    _bits_per_component: GuestUSize,
+    _bits_per_pixel: GuestUSize,
+    _bytes_per_row: GuestUSize,
+    _space: CGColorSpaceRef,
+    _bitmap_info: CGBitmapInfo,
+    provider: CGDataProviderRef,
+    decode: ConstPtr<CGFloat>,
+    _should_interpolate: bool,
+    _intent: CGColorRenderingIntent,
+) -> CGImageRef {
+    assert!(decode.is_null());
+    let bytes = cg_data_provider::borrow_bytes(env, provider);
+    from_image(env, Image::from_pixel_vec(bytes.to_vec(), (width, height), 4))
+}
+
+fn CGImageMaskCreate(
+    env: &mut Environment,
+    width: GuestUSize,
+    height: GuestUSize,
+    _bits_per_component: GuestUSize,
+    _bits_per_pixel: GuestUSize,
+    _bytes_per_row: GuestUSize,
+    provider: CGDataProviderRef,
+    decode: ConstPtr<CGFloat>,
+    _should_interpolate: bool,
+) -> CGImageRef {
+    assert!(decode.is_null());
+    let bytes = cg_data_provider::borrow_bytes(env, provider);
+    from_image(env, Image::from_pixel_vec(bytes.to_vec(), (width, height), 1))
+}
+
 fn CGImageCreateWithPNGDataProvider(
     env: &mut Environment,
     source: CGDataProviderRef,
     decode: ConstPtr<CGFloat>,
-    _should_interpolate: bool, // TODO
-    _intent: i32,              // TODO (should be CGColorRenderingIntent)
+    _should_interpolate: bool,       // TODO
+    _intent: CGColorRenderingIntent, // TODO (should be CGColorRenderingIntent)
 ) -> CGImageRef {
     assert!(decode.is_null()); // TODO
 
@@ -167,6 +205,8 @@ fn CGImageGetBitsPerComponent(_: &mut Environment, _: CGImageRef) -> GuestUSize 
 pub const FUNCTIONS: FunctionExports = &[
     export_c_func!(CGImageRelease(_)),
     export_c_func!(CGImageRetain(_)),
+    export_c_func!(CGImageCreate(_, _, _, _, _, _, _, _, _, _, _)),
+    export_c_func!(CGImageMaskCreate(_, _, _, _, _, _, _, _)),
     export_c_func!(CGImageCreateWithPNGDataProvider(_, _, _, _)),
     export_c_func!(CGImageGetAlphaInfo(_)),
     export_c_func!(CGImageGetColorSpace(_)),

--- a/src/frameworks/foundation.rs
+++ b/src/frameworks/foundation.rs
@@ -30,6 +30,7 @@ pub mod ns_exception;
 pub mod ns_file_handle;
 pub mod ns_file_manager;
 pub mod ns_keyed_unarchiver;
+pub mod ns_keyed_archiver;
 pub mod ns_locale;
 pub mod ns_lock;
 pub mod ns_log;

--- a/src/frameworks/foundation/ns_keyed_archiver.rs
+++ b/src/frameworks/foundation/ns_keyed_archiver.rs
@@ -1,0 +1,82 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+//! `NSKeyedArchiver` - Currently just a fake implementation.
+
+use crate::objc::{
+    autorelease, id, msg_class, nil, objc_classes, ClassExports, HostObject,
+    NSZonePtr,
+};
+use crate::Environment;
+use plist::Dictionary;
+
+struct NSKeyedArchiverHostObject {
+    data: id,
+    plist: Dictionary,
+    /// Something responding to NSKeyedUnarchiverDelegate
+    delegate: id,
+}
+impl HostObject for NSKeyedArchiverHostObject {}
+
+pub const CLASSES: ClassExports = objc_classes! {
+
+(env, this, _cmd);
+
+@implementation NSKeyedArchiver: NSCoder
+
++ (id)allocWithZone:(NSZonePtr)_zone { // struct _NSZone*
+    let archiver = Box::new(NSKeyedArchiverHostObject {
+        delegate: nil,
+        data: nil,
+        plist: Dictionary::new(),
+    });
+    env.objc.alloc_object(this, archiver, &mut env.mem)
+}
+
++ (id)archivedDataWithRootObject:(id)_rootObject { // NSData *
+    let data: id = msg_class![env; NSMutableData new];
+    autorelease(env, data)
+}
+
+// TODO: other init methods.
+
+- (id)initForWritingWithMutableData:(id)data { // NSData *
+    if data == nil {
+        return nil;
+    }
+
+    let host_obj = env.objc.borrow_mut::<NSKeyedArchiverHostObject>(this);
+    assert!(host_obj.data.is_null());
+
+    host_obj.data = data;
+    host_obj.plist = Dictionary::new();
+
+    this
+}
+
+- (())dealloc {
+    env.objc.dealloc_object(this, &mut env.mem)
+}
+
+// TODO: implement calls to delegate methods
+// weak/non-retaining
+- (())setDelegate:(id)delegate { // id<NSKeyedUnarchiverDelegate>
+    let host_object = env.objc.borrow_mut::<NSKeyedArchiverHostObject>(this);
+    host_object.delegate = delegate;
+}
+- (id)delegate {
+    env.objc.borrow::<NSKeyedArchiverHostObject>(this).delegate
+}
+
+- (bool)containsValueForKey:(id)key { // NSString*
+    assert!(key != nil);
+    return false;
+}
+
+// TODO: add more decode methods
+
+@end
+
+};

--- a/src/frameworks/foundation/ns_locale.rs
+++ b/src/frameworks/foundation/ns_locale.rs
@@ -77,6 +77,9 @@ fn get_preferred_languages(options: &Options) -> Vec<String> {
 }
 
 fn get_preferred_countries() -> Vec<String> {
+    let country = "US".to_string();
+    log!("The app requested your current locale. {:?} will be reported.", country);
+    return vec![country];
     // Unfortunately Rust-SDL2 doesn't provide a wrapper for this yet.
     let countries = unsafe {
         let mut countries = Vec::new();
@@ -189,6 +192,7 @@ pub const CLASSES: ClassExports = objc_classes! {
 
 - (id)objectForKey:(id)key {
     let key_str: &str = &ns_string::to_rust_string(env, key);
+    log!("Key: {}", key_str);
     match key_str {
         // Note: this is not the cleanest separation between NS and CF parts
         // But it does work on the iOS Simulator

--- a/src/frameworks/foundation/ns_locale.rs
+++ b/src/frameworks/foundation/ns_locale.rs
@@ -76,10 +76,17 @@ fn get_preferred_languages(options: &Options) -> Vec<String> {
     }
 }
 
-fn get_preferred_countries() -> Vec<String> {
-    let country = "US".to_string();
-    log!("The app requested your current locale. {:?} will be reported.", country);
-    return vec![country];
+fn get_preferred_countries(env: &mut Environment) -> Vec<String> {
+    if env
+        .bundle
+        .bundle_identifier()
+        .starts_with("com.ea.causeofdeath")
+    {
+        // TODO Cause of Death crashes with non-US countries? Check on real device.
+        let country = "US".to_string();
+        log!("The app requested your current locale. {:?} will be reported.", country);
+        return vec![country];
+    }
     // Unfortunately Rust-SDL2 doesn't provide a wrapper for this yet.
     let countries = unsafe {
         let mut countries = Vec::new();
@@ -144,7 +151,7 @@ pub const CLASSES: ClassExports = objc_classes! {
     if let Some(locale) = State::get(env).current_locale {
         locale
     } else {
-        let countries = get_preferred_countries();
+        let countries = get_preferred_countries(env);
         let country_code = ns_string::from_rust_string(env, countries[0].clone());
         let host_object = NSLocaleHostObject {
             country_code
@@ -191,7 +198,11 @@ pub const CLASSES: ClassExports = objc_classes! {
 }
 
 - (id)objectForKey:(id)key {
-    let key_str: &str = &ns_string::to_rust_string(env, key);
+    let key_str: &str = if key.is_null() {
+        NSLocaleCountryCode
+    } else {
+        &ns_string::to_rust_string(env, key)
+    };
     log!("Key: {}", key_str);
     match key_str {
         // Note: this is not the cleanest separation between NS and CF parts

--- a/src/frameworks/uikit/ui_application.rs
+++ b/src/frameworks/uikit/ui_application.rs
@@ -190,6 +190,14 @@ pub const CLASSES: ClassExports = objc_classes! {
     log!("TODO: ignoring setApplicationIconBadgeNumber:{}", bn);
 }
 
+- (NSInteger)applicationIconBadgeNumber {
+    log!("TODO: ignoring applicationIconBadgeNumber");
+    0
+}
+
+- (())setApplicationSupportsShakeToEdit:(bool)enable {
+    log!("TODO: ignoring setApplicationSupportsShakeToEdit:{}",enable);
+}
 // UIResponder implementation
 // From the Apple UIView docs regarding [UIResponder nextResponder]:
 // "The shared UIApplication object normally returns nil, but it returns its

--- a/src/frameworks/uikit/ui_application.rs
+++ b/src/frameworks/uikit/ui_application.rs
@@ -9,7 +9,7 @@ use super::ui_device::*;
 use crate::dyld::{export_c_func, ConstantExports, FunctionExports, HostConstant};
 use crate::frameworks::foundation::ns_string::{from_rust_string, get_static_str};
 use crate::frameworks::foundation::{ns_array, ns_string, NSInteger, NSUInteger};
-use crate::mem::MutPtr;
+use crate::mem::{ConstVoidPtr, MutPtr};
 use crate::objc::{
     autorelease, id, msg, msg_class, nil, objc_classes, release, retain, ClassExports, HostObject,
     NSZonePtr,
@@ -57,6 +57,9 @@ pub const CLASSES: ClassExports = objc_classes! {
     assert!(env.framework_state.uikit.ui_application.shared_application.is_none());
     env.framework_state.uikit.ui_application.shared_application = Some(this);
     this
+}
+
+- (()) sendEvent:(ConstVoidPtr)_event {
 }
 
 // This is a singleton, it shouldn't be deallocated.

--- a/src/frameworks/uikit/ui_font.rs
+++ b/src/frameworks/uikit/ui_font.rs
@@ -222,7 +222,7 @@ pub fn size_with_font(
 }
 
 #[inline(always)]
-fn draw_font_glyph(
+pub(crate) fn draw_font_glyph(
     drawer: &mut CGBitmapContextDrawer,
     raster_glyph: crate::font::RasterGlyph,
     fill_color: (f32, f32, f32, f32),

--- a/src/frameworks/uikit/ui_graphics.rs
+++ b/src/frameworks/uikit/ui_graphics.rs
@@ -6,11 +6,18 @@
 //! `UIGraphics.h`
 
 use crate::dyld::{export_c_func, FunctionExports};
+use crate::frameworks::core_graphics::cg_bitmap_context::CGBitmapContextCreate;
+use crate::frameworks::core_graphics::cg_color_space::CGColorSpaceCreateDeviceRGB;
 use crate::frameworks::core_graphics::cg_context::{
     CGContextRef, CGContextRelease, CGContextRetain,
 };
-use crate::objc::nil;
+use crate::frameworks::core_graphics::cg_image::{kCGImageAlphaPremultipliedLast, kCGImageByteOrder32Big};
+use crate::frameworks::core_graphics::CGSize;
+use crate::mem::{GuestUSize, MutVoidPtr};
+use crate::objc::{id, nil};
 use crate::Environment;
+
+pub type UIImageRef = id;
 
 #[derive(Default)]
 pub(super) struct State {
@@ -38,9 +45,30 @@ pub fn UIGraphicsGetCurrentContext(env: &mut Environment) -> CGContextRef {
         .copied()
         .unwrap_or(nil)
 }
+pub fn UIGraphicsBeginImageContext(env: &mut Environment, size: CGSize) {
+    let width = size.width as GuestUSize;
+    let height = size.height as GuestUSize;
+    let color_space = CGColorSpaceCreateDeviceRGB(env);
+    let context = CGBitmapContextCreate(
+        env, MutVoidPtr::null(), width, height, 8, width * 4,
+        color_space,
+        kCGImageByteOrder32Big | kCGImageAlphaPremultipliedLast,
+    );
+    UIGraphicsPushContext(env, context);
+}
+pub fn UIGraphicsEndImageContext(env: &mut Environment) {
+    UIGraphicsPopContext(env);
+}
+
+pub fn UIGraphicsGetImageFromCurrentImageContext(_env: &mut Environment) -> UIImageRef {
+    nil
+}
 
 pub const FUNCTIONS: FunctionExports = &[
     export_c_func!(UIGraphicsPushContext(_)),
     export_c_func!(UIGraphicsPopContext()),
     export_c_func!(UIGraphicsGetCurrentContext()),
+    export_c_func!(UIGraphicsBeginImageContext(_)),
+    export_c_func!(UIGraphicsEndImageContext()),
+    export_c_func!(UIGraphicsGetImageFromCurrentImageContext()),
 ];

--- a/src/frameworks/uikit/ui_view.rs
+++ b/src/frameworks/uikit/ui_view.rs
@@ -25,12 +25,13 @@ use crate::frameworks::core_graphics::cg_color::CGColorRef;
 use crate::frameworks::core_graphics::cg_context::{CGContextClearRect, CGContextRef};
 use crate::frameworks::core_graphics::{CGFloat, CGPoint, CGRect, CGSize};
 use crate::frameworks::foundation::ns_string::get_static_str;
-use crate::frameworks::foundation::{ns_array, NSInteger, NSUInteger};
+use crate::frameworks::foundation::{ns_array, NSInteger, NSTimeInterval, NSUInteger};
 use crate::objc::{
     autorelease, id, msg, msg_class, nil, objc_classes, release, retain, Class, ClassExports,
     HostObject, NSZonePtr,
 };
 use crate::Environment;
+use crate::mem::MutVoidPtr;
 
 #[derive(Default)]
 pub struct State {
@@ -111,6 +112,15 @@ pub const CLASSES: ClassExports = objc_classes! {
 + (Class)layerClass {
     env.objc.get_known_class("CALayer", &mut env.mem)
 }
+
+
++ (()) beginAnimations: (id)_animationID context: (MutVoidPtr)_context {}
+
++ (()) setAnimationCurve: (NSInteger) _curve {}
++ (()) setAnimationDuration: (NSTimeInterval) _duration {}
++ (()) setAnimationDelay: (NSTimeInterval) _delay {}
+
++ (()) commitAnimations {}
 
 // TODO: accessors etc
 

--- a/src/frameworks/uikit/ui_view/ui_control/ui_button.rs
+++ b/src/frameworks/uikit/ui_view/ui_control/ui_button.rs
@@ -389,6 +389,10 @@ pub const CLASSES: ClassExports = objc_classes! {
     }
 }
 
+- (()) setImageEdgeInsets:(CGRect)rect {
+    log!("setImageEdgeInsets: {:?}", rect);
+}
+
 @end
 
 // Undocumented classes used by NIBs

--- a/src/image.rs
+++ b/src/image.rs
@@ -20,6 +20,7 @@ use touchHLE_stb_image_wrapper::*;
 pub struct Image {
     pixels: PixelStore,
     dimensions: (u32, u32),
+    bytes_per_pixel: u32,
 }
 
 enum PixelStore {
@@ -81,16 +82,18 @@ impl Image {
         Ok(Image {
             pixels: PixelStore::StbImage(pixels),
             dimensions: (width, height),
+            bytes_per_pixel: 4,
         })
     }
 
     /// TODO: This shouldn't really exist, it's a workaround for `CGImage`
     /// relying on this type and should be removed once it can be refactored.
-    pub fn from_pixel_vec(pixels: Vec<u8>, dimensions: (u32, u32)) -> Image {
-        assert!(dimensions.0 as usize * 4 * dimensions.1 as usize == pixels.len());
+    pub fn from_pixel_vec(pixels: Vec<u8>, dimensions: (u32, u32), bpp: u32) -> Image {
+        assert!(dimensions.0 as usize * bpp as usize * dimensions.1 as usize == pixels.len());
         Image {
             pixels: PixelStore::Vec(pixels),
             dimensions,
+            bytes_per_pixel: bpp,
         }
     }
 

--- a/src/libc/mach_time.rs
+++ b/src/libc/mach_time.rs
@@ -38,7 +38,7 @@ fn mach_timebase_info(
 /// The result of this function, multiplied by the constant from
 /// [mach_timebase_info], should be the absolute time in nanoseconds.
 /// The absolute time is a monotonic clock with an arbitrary starting point.
-fn mach_absolute_time(env: &mut Environment) -> u64 {
+pub fn mach_absolute_time(env: &mut Environment) -> u64 {
     let now = Instant::now();
     now.duration_since(env.startup_time)
         .as_nanos()

--- a/src/objc.rs
+++ b/src/objc.rs
@@ -30,13 +30,13 @@ mod properties;
 mod selectors;
 mod synchronization;
 
-pub use classes::{objc_classes, Class, ClassExports, ClassTemplate};
+pub use classes::{objc_classes, Class, ClassExports, ClassTemplate, objc_getClass, class_getSuperclass, class_getInstanceMethod, method_getImplementation};
 pub use messages::{
     autorelease, msg, msg_class, msg_send, msg_send_super2, msg_super, objc_super, release, retain,
 };
 pub use methods::{HostIMP, IMP};
 pub use objects::{
-    id, impl_HostObject_with_superclass, nil, AnyHostObject, HostObject, TrivialHostObject,
+    id, impl_HostObject_with_superclass, nil, AnyHostObject, HostObject, TrivialHostObject, object_getClass,
 };
 pub use selectors::{selector, SEL};
 
@@ -51,6 +51,7 @@ use objects::{objc_object, HostObjectEntry};
 use properties::{ivar_list_t, objc_copyStruct, objc_getProperty, objc_setProperty};
 use selectors::sel_registerName;
 use synchronization::{objc_sync_enter, objc_sync_exit};
+use crate::objc::classes::method_setImplementation;
 
 /// Typedef for `NSZone *`. This is a [fossil type] found in the signature of
 /// `allocWithZone:` and similar methods. Its value is always ignored.
@@ -120,4 +121,10 @@ pub const FUNCTIONS: FunctionExports = &[
     export_c_func!(objc_sync_exit(_)),
     export_c_func!(sel_registerName(_)),
     export_c_func!(_Block_object_dispose(_, _)),
+    export_c_func!(objc_getClass(_)),
+    export_c_func!(object_getClass(_)),
+    export_c_func!(class_getSuperclass(_)),
+    export_c_func!(class_getInstanceMethod(_, _)),
+    export_c_func!(method_getImplementation(_)),
+    export_c_func!(method_setImplementation(_, _)),
 ];

--- a/src/objc/classes.rs
+++ b/src/objc/classes.rs
@@ -646,10 +646,15 @@ impl ObjC {
                 .unwrap()
                 .as_any()
                 .downcast_ref();
-            let Some(ClassHostObject { superclass, .. }) = class_host_object else {
+            let Some(ClassHostObject { superclass, methods, ivars, .. }) = class_host_object else {
                 // Skip FakeClass or UnimplementedClass
                 continue;
             };
+
+            if methods.is_empty() && ivars.is_empty() {
+                // Skip classes with no methods or attributes, these seem to be loading with null superclass?
+                continue;
+            }
 
             if *superclass != nil {
                 inverted_inheritance

--- a/src/objc/classes.rs
+++ b/src/objc/classes.rs
@@ -18,8 +18,12 @@ use super::{
     IMP, SEL,
 };
 use crate::mach_o::MachO;
-use crate::mem::{guest_size_of, ConstPtr, ConstVoidPtr, GuestUSize, Mem, Ptr, SafeRead};
+use crate::mem::{guest_size_of, ConstPtr, ConstVoidPtr, GuestUSize, Mem, Ptr, SafeRead, SafeWrite};
 use std::collections::{HashMap, VecDeque};
+use std::ops::Add;
+use crate::abi::{CallFromGuest, GuestFunction};
+use crate::environment::Environment;
+use crate::objc::methods::GuestIMP;
 
 /// Generic pointer to an Objective-C class or metaclass.
 ///
@@ -869,4 +873,71 @@ impl ObjC {
             panic!();
         }
     }
+}
+
+pub fn objc_getClass(env: &mut Environment, name: ConstPtr<u8>) -> id {
+    let name = env.mem.cstr_at_utf8(name).unwrap();
+    env.objc.get_class(name, false, &env.mem).unwrap()
+}
+
+pub fn class_getSuperclass(env: &mut Environment, class: Class) -> Class {
+    let obj: &ClassHostObject = env.objc.get_host_object(class.cast()).unwrap().as_any().downcast_ref().unwrap();
+    obj.superclass
+}
+
+pub struct MethodRef(Class, SEL);
+
+unsafe impl SafeRead for MethodRef {}
+
+pub fn class_getInstanceMethod(env: &mut Environment, class: Class, name: SEL) -> ConstPtr<MethodRef> {
+    let obj: &ClassHostObject = env.objc.get_host_object(class.cast()).unwrap().as_any().downcast_ref().unwrap();
+    let opt = obj.methods.iter().find(|&(method, _i)| method.eq(&name));
+    let str_name = name.as_str(&env.mem);
+    if let None = opt {
+        if obj.superclass != nil {
+            return class_getInstanceMethod(env, obj.superclass, name);
+        }
+        log!("Method {}::{} not found!", obj.name, str_name);
+        return ConstPtr::null();
+    }
+    env.mem.alloc_and_write(MethodRef(class, name)).cast_const()
+}
+
+pub fn method_getImplementation(env: &mut Environment, method: ConstPtr<MethodRef>) -> ConstVoidPtr {
+    let method = env.mem.read(method);
+    get_implementation_ptr(env, method)
+}
+
+fn get_implementation_ptr(env: &mut Environment, method: MethodRef) -> ConstVoidPtr {
+    let (class, name) = (method.0, method.1);
+    let obj: &ClassHostObject = env.objc.get_host_object(class.cast()).unwrap().as_any().downcast_ref().unwrap();
+    let opt = obj.methods.iter().find(|&(method, _i)| method.eq(&name));
+    let str_name = name.as_str(&env.mem);
+    let ptr = match opt {
+        None => {
+            panic!("Method {}::{} not found!", obj.name, str_name)
+        }
+        Some((_, imp)) => {
+            match imp {
+                IMP::Host(hostimp) => {
+                    env.dyld.create_guest_hostimp(&mut env.mem, "HostFN", *hostimp).to_ptr()
+                }
+                IMP::Guest(guestimp) => {
+                    guestimp.to_ptr()
+                }
+            }
+        }
+    };
+    log!("Returning ptr to: {:#x}", ptr.to_bits());
+    ptr
+}
+
+pub fn method_setImplementation(env: &mut Environment, method: ConstPtr<MethodRef>, imp: ConstVoidPtr) -> ConstVoidPtr {
+    let method = env.mem.read(method);
+    let (class, name) = (method.0, method.1);
+    let old = get_implementation_ptr(env, method);
+    let obj: &mut ClassHostObject = env.objc.borrow_mut(class.cast());
+    obj.methods.remove(&name);
+    obj.methods.insert(name, IMP::Guest(GuestFunction::from_addr_with_thumb_bit(imp.to_bits())));
+    old
 }

--- a/src/objc/classes.rs
+++ b/src/objc/classes.rs
@@ -18,12 +18,10 @@ use super::{
     IMP, SEL,
 };
 use crate::mach_o::MachO;
-use crate::mem::{guest_size_of, ConstPtr, ConstVoidPtr, GuestUSize, Mem, Ptr, SafeRead, SafeWrite};
+use crate::mem::{guest_size_of, ConstPtr, ConstVoidPtr, GuestUSize, Mem, Ptr, SafeRead};
 use std::collections::{HashMap, VecDeque};
-use std::ops::Add;
-use crate::abi::{CallFromGuest, GuestFunction};
+use crate::abi::{GuestFunction};
 use crate::environment::Environment;
-use crate::objc::methods::GuestIMP;
 
 /// Generic pointer to an Objective-C class or metaclass.
 ///
@@ -360,11 +358,22 @@ impl ClassHostObject {
                     template.instance_methods
                 })
                 .iter()
-                .map(|&(name, host_imp)| {
+                .flat_map(|&(name, host_imp)| {
+                    // handle cases like functionWithControlPoints:::: where multiple objc
+                    // arguments without verb exist, which rust macro can't handle
+                    let sanitized_name = name
+                        .split(':')
+                        .map(|c| if c.starts_with('_') {""} else {c})
+                        .collect::<Vec<&str>>()
+                        .join(":");
+
                     // The selector should already have been registered by
                     // [ObjC::register_host_selectors], so we can panic
                     // if it hasn't been.
-                    (objc.selectors[name], IMP::Host(host_imp))
+                    [
+                        (objc.selectors[name], IMP::Host(host_imp)),
+                        (objc.selectors[sanitized_name.as_str()], IMP::Host(host_imp))
+                    ]
                 }),
             ),
             // maybe this should be 0 for NSObject? does it matter?
@@ -438,7 +447,8 @@ fn substitute_classes(
         || name.starts_with("AltAds")
         || name.starts_with("Mobclix")
         || name.starts_with("Flurry")
-        || name.starts_with("OpenFeint"))
+        || name.starts_with("OpenFeint")
+        || name.starts_with("Tapjoy"))
     {
         return None;
     }

--- a/src/objc/classes/class_lists.rs
+++ b/src/objc/classes/class_lists.rs
@@ -23,6 +23,7 @@ pub const CLASS_LISTS: &[super::ClassExports] = &[
     core_graphics::cg_color_space::CLASSES,
     core_graphics::cg_context::CLASSES,
     core_graphics::cg_image::CLASSES,
+    core_graphics::cg_font::CLASSES,
     core_foundation::cf_run_loop_timer::CLASSES, // Special internal classes.
     core_location::CLASSES,
     game_kit::gk_local_player::CLASSES,
@@ -41,6 +42,7 @@ pub const CLASS_LISTS: &[super::ClassExports] = &[
     foundation::ns_file_handle::CLASSES,
     foundation::ns_file_manager::CLASSES,
     foundation::ns_keyed_unarchiver::CLASSES,
+    foundation::ns_keyed_archiver::CLASSES,
     foundation::ns_locale::CLASSES,
     foundation::ns_lock::CLASSES,
     foundation::ns_notification::CLASSES,

--- a/src/objc/messages.rs
+++ b/src/objc/messages.rs
@@ -82,10 +82,6 @@ fn objc_msgSend_inner(env: &mut Environment, receiver: id, selector: SEL, super2
             ..
         }) = host_object.as_any().downcast_ref()
         {
-            let name_str = name.clone();
-            let name = name_str.as_str();
-            let sel_name = selector.as_str(&env.mem);
-            log!("Calling {}::{}", name, sel_name);
             // Skip method lookup on first iteration if this is the super-call
             // variant of objc_msgSend (look up the superclass first)
             if super2.is_some() && class == orig_class {

--- a/src/objc/messages.rs
+++ b/src/objc/messages.rs
@@ -78,9 +78,14 @@ fn objc_msgSend_inner(env: &mut Environment, receiver: id, selector: SEL, super2
         if let Some(&super::ClassHostObject {
             superclass,
             ref methods,
+            ref name,
             ..
         }) = host_object.as_any().downcast_ref()
         {
+            let name_str = name.clone();
+            let name = name_str.as_str();
+            let sel_name = selector.as_str(&env.mem);
+            log!("Calling {}::{}", name, sel_name);
             // Skip method lookup on first iteration if this is the super-call
             // variant of objc_msgSend (look up the superclass first)
             if super2.is_some() && class == orig_class {

--- a/src/objc/methods.rs
+++ b/src/objc/methods.rs
@@ -73,6 +73,7 @@ macro_rules! impl_HostIMP {
         {
             type WithoutSuper = (R, (id, SEL, $($P,)*));
         }
+
     }
 }
 

--- a/src/objc/objects.rs
+++ b/src/objc/objects.rs
@@ -24,6 +24,7 @@ use super::{Class, ClassHostObject};
 use crate::mem::{guest_size_of, GuestUSize, Mem, MutPtr, Ptr, SafeRead};
 use std::any::Any;
 use std::num::NonZeroU32;
+use crate::environment::Environment;
 
 /// Memory layout of a minimal Objective-C object. See [id].
 ///
@@ -365,4 +366,10 @@ impl super::ObjC {
 
         mem.free(object.cast());
     }
+}
+
+pub fn object_getClass(env: &mut Environment, obj: id) -> Class {
+    let obj: Ptr<objc_object, true> = obj.cast();
+    let obj = env.mem.read(obj);
+    obj.isa
 }

--- a/src/objc/selectors.rs
+++ b/src/objc/selectors.rs
@@ -96,6 +96,19 @@ impl ObjC {
             for (_name, template) in class_list {
                 for method_list in [template.class_methods, template.instance_methods] {
                     for &(name, _imp) in method_list {
+                        // handle cases like functionWithControlPoints:::: where multiple objc
+                        // arguments without verb exist, which rust macro can't handle
+                        let sanitized_name = name
+                            .split(':')
+                            .map(|c| if c.starts_with('_') {""} else {c})
+                            .collect::<Vec<&str>>()
+                            .join(":");
+                        if sanitized_name.as_str() != name {
+                            if !self.selectors.contains_key(sanitized_name.as_str()) {
+                                let sel = SEL(mem.alloc_and_write_cstr(sanitized_name.as_str().as_bytes()).cast_const());
+                                self.selectors.insert(sanitized_name.as_str().to_string(), sel);
+                            }
+                        }
                         if self.selectors.contains_key(name) {
                             continue;
                         }


### PR DESCRIPTION
Hi!
This PR implements some stuff that's required to get Cause of Death booting:

- method_getImplementation / method_setImplementation / object_getClass
- CGFont (requires ttf-parser which was already an indirect dependency)
- CATransform
- general mocks of missing methods in other classes
- allow CFRunLoopTimerCreate's context_ptr to be null (allowed according to [Apple docs](https://developer.apple.com/documentation/corefoundation/cfrunlooptimercreate(_:_:_:_:_:_:_:)?language=objc), see "context" parameter
- rewrite selector names when text before colon is underscored (some selectors don't have text before colon but rust macro apparently can't handle it?)

However, even with all of this Cause of Death does not boot properly. One of its' classes (SHSAnimationLayer::finalizeAnimation] apparently tries to access a null pointer. Even if that's allowed to happen (by commenting Mem::bytes_at's null segment check), text on the start screen comes up garbled:
![image](https://github.com/user-attachments/assets/e4e6e038-feb9-42ed-aae9-f21bc6450e5e)
(this is supposed to say "Play game with sound enabled?"), which indicates either corruption (as would be expected if the game is reading off of null pointer) or mis-interpretation of the cmap table (as the CGFont API provides the raw table from the TTF file instead of a parsed structure).