### PR TITLE
Fix NPOT/PowerVR texture bug

### DIFF
--- a/src/frameworks/core_animation/composition.rs
+++ b/src/frameworks/core_animation/composition.rs
@@ -177,6 +177,21 @@ pub fn recomposite_if_necessary(env: &mut Environment, force: bool) -> Option<In
                 gles11::LINEAR as _,
             );
 
+            // iOS and PowerVR only support NPOT texture with CLAMP_TO_EDGE
+            // It doesn't matter for texture data from an image, we don't
+            // want to deal with striping from NPOT to POT conversion.
+            gles.TexParameteri(
+                gles11::TEXTURE_2D,
+                gles11::TEXTURE_WRAP_S,
+                gles11::CLAMP_TO_EDGE as _,
+            );
+
+            gles.TexParameteri(
+                gles11::TEXTURE_2D,
+                gles11::TEXTURE_WRAP_T,
+                gles11::CLAMP_TO_EDGE as _,
+            );
+
             gles.GenFramebuffersOES(1, &mut framebuffer);
             gles.BindFramebufferOES(gles11::FRAMEBUFFER_OES, framebuffer);
             gles.FramebufferTexture2DOES(
@@ -479,5 +494,19 @@ unsafe fn upload_rgba8_pixels(gles: &mut dyn GLES, pixels: &[u8], dimensions: (u
         gles11::TEXTURE_2D,
         gles11::TEXTURE_MAG_FILTER,
         gles11::LINEAR as _,
+    );
+
+    // iOS and PowerVR only support NPOT texture with CLAMP_TO_EDGE
+    // It doesn't matter for texture data from an image, we don't
+    // want to deal with striping from NPOT to POT conversion.
+    gles.TexParameteri(
+        gles11::TEXTURE_2D,
+        gles11::TEXTURE_WRAP_S,
+        gles11::CLAMP_TO_EDGE as _,
+    );
+    gles.TexParameteri(
+        gles11::TEXTURE_2D,
+        gles11::TEXTURE_WRAP_T,
+        gles11::CLAMP_TO_EDGE as _,
     );
 }

--- a/src/frameworks/core_animation/composition.rs
+++ b/src/frameworks/core_animation/composition.rs
@@ -272,6 +272,7 @@ pub fn recomposite_if_necessary(env: &mut Environment, force: bool) -> Option<In
             present_frame_args.0,
             present_frame_args.1,
             present_frame_args.2,
+            None,
         );
     }
     env.window().swap_window();

--- a/src/frameworks/opengles/eagl.rs
+++ b/src/frameworks/opengles/eagl.rs
@@ -13,12 +13,12 @@ use crate::frameworks::foundation::ns_string::get_static_str;
 use crate::frameworks::foundation::NSUInteger;
 use crate::gles::gles11_raw as gles11; // constants only
 use crate::gles::gles11_raw::types::*;
-use crate::gles::present::{present_frame, FpsCounter};
+use crate::gles::present::{present_frame, FpsCounter, TextureCoordinates};
 use crate::gles::{create_gles1_ctx, gles1_on_gl2, GLES};
 use crate::mem::MutPtr;
 use crate::objc::{id, msg, nil, objc_classes, release, retain, ClassExports, HostObject};
 use crate::options::Options;
-use crate::window::Window;
+use crate::window::{DeviceOrientation, Window};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -544,7 +544,8 @@ unsafe fn present_renderbuffer(gles: &mut dyn GLES, window: &mut Window) {
     // rotated, scaled or letterboxed as appropriate.
 
     let renderbuffer: GLuint = get_int(gles, gles11::RENDERBUFFER_BINDING_OES) as _;
-    let (width, height) = get_renderbuffer_size(gles);
+    let (render_width, render_height) = get_renderbuffer_size(gles);
+    let (texture_width, texture_height) = to_pot_texture_dim(render_width as _, render_height as _);
 
     // To avoid confusing the guest app, we need to be able to undo any
     // state changes we make.
@@ -566,15 +567,43 @@ unsafe fn present_renderbuffer(gles: &mut dyn GLES, window: &mut Window) {
     let mut texture: GLuint = 0;
     gles.GenTextures(1, &mut texture);
     gles.BindTexture(gles11::TEXTURE_2D, texture);
-    gles.CopyTexImage2D(
+    gles.TexImage2D(
         gles11::TEXTURE_2D,
         0,
-        gles11::RGB as _,
+        gles11::RGBA as _,
+        texture_width as _,
+        texture_height as _,
+        0,
+        gles11::RGBA,
+        gles11::UNSIGNED_BYTE,
+        std::ptr::null(),
+    );
+
+    // The NPOT source framebuffer is always an unrotated, portrait texture.
+    // When copying to the POT render texture, we need to accommodate for this
+    // by adjusting both texture coordinates, and where in the POT texture
+    // it ends up so we don't sample from uninitialized pixels.
+    let (xoffset, yoffset) = match window.current_rotation() {
+        // No offset needed as the source matches the target.
+        DeviceOrientation::Portrait => (0, 0),
+        // With a landscape left orientation, the top left corner of the screen
+        // is rotated to the bottom left corner, so we need to shift the texture
+        // to the top left corner of the POT target.
+        DeviceOrientation::LandscapeLeft => (0, texture_height.abs_diff(render_height as _)),
+        // With landscape right, the bottom right corner is sampled as 0,0,
+        // so we need to shift the texture to the bottom right
+        DeviceOrientation::LandscapeRight => (texture_width.abs_diff(render_width as _), 0),
+    };
+
+    gles.CopyTexSubImage2D(
+        gles11::TEXTURE_2D,
+        0,
+        xoffset as _,
+        yoffset as _,
         0,
         0,
-        width,
-        height,
-        0,
+        render_width as _,
+        render_height as _,
     );
     // The texture will not have any mip levels so we must ensure the filter
     // does not use them, else rendering will fail.
@@ -659,6 +688,13 @@ unsafe fn present_renderbuffer(gles: &mut dyn GLES, window: &mut Window) {
         window.viewport(),
         window.rotation_matrix(),
         window.virtual_cursor_visible_at(),
+        Some(&TextureCoordinates::normalized(
+            render_width as _,
+            render_height as _,
+            texture_width,
+            texture_height,
+            window.current_rotation(),
+        )),
     );
 
     // Clean up the texture
@@ -735,4 +771,10 @@ unsafe fn present_renderbuffer(gles: &mut dyn GLES, window: &mut Window) {
     gles.BindFramebufferOES(gles11::FRAMEBUFFER_OES, old_framebuffer);
 
     //{ let err = gl21::GetError(); if err != 0 { panic!("{:#x}", err); } }
+}
+
+fn to_pot_texture_dim(width: u32, height: u32) -> (u32, u32) {
+    let width = width.next_power_of_two();
+    let height = height.next_power_of_two();
+    (width, height)
 }

--- a/src/gles/present.rs
+++ b/src/gles/present.rs
@@ -9,6 +9,7 @@
 use super::gles11_raw as gles11; // constants and types only
 use super::GLES;
 use crate::matrix::Matrix;
+use crate::window::DeviceOrientation;
 use std::time::{Duration, Instant};
 
 pub struct FpsCounter {
@@ -38,17 +39,66 @@ impl FpsCounter {
     }
 }
 
+pub struct TextureCoordinates {
+    tex_coords: [f32; 12],
+}
+
+impl TextureCoordinates {
+    pub const fn unnormalized() -> &'static TextureCoordinates {
+        &TextureCoordinates {
+            tex_coords: [0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+        }
+    }
+
+    pub const fn normalized(
+        render_width: u32,
+        render_height: u32,
+        texture_width: u32,
+        texture_height: u32,
+        device_orientation: DeviceOrientation,
+    ) -> TextureCoordinates {
+        let (render_width, render_height) = match device_orientation {
+            DeviceOrientation::Portrait => (render_width, render_height),
+            _ => (render_height, render_width),
+        };
+
+        let (texture_width, texture_height) = match device_orientation {
+            DeviceOrientation::Portrait => (texture_width, texture_height),
+            _ => (texture_height, texture_width),
+        };
+
+        let normal_w = (render_width as f32) / texture_width as f32;
+        let normal_h = (render_height as f32) / texture_height as f32;
+
+        #[rustfmt::skip]
+        let tex_coords: [f32; 12] = [
+            0.0, 0.0,
+            0.0, normal_h,
+            normal_w, 0.0,
+            normal_w, 0.0,
+            0.0, normal_h,
+            normal_w, normal_h,
+        ];
+
+        Self { tex_coords }
+    }
+}
+
 /// Present the the latest frame (e.g. the app's splash screen or rendering
 /// output), provided as a texture bound to `GL_TEXTURE_2D`, by drawing it on
 /// the window. It may be rotated, scaled and/or letterboxed as necessary. The
 /// virtual cursor is also drawn if it should be currently visible.
 ///
 /// The provided context must be current.
+///
+/// If `normalized_texture_coords` is provided, then texture coordinates will
+/// be normalized with the provided UV width and height factors.
 pub unsafe fn present_frame(
     gles: &mut dyn GLES,
     viewport: (u32, u32, u32, u32),
     rotation_matrix: Matrix<2>,
     virtual_cursor_visible_at: Option<(f32, f32, bool)>,
+    normalized_texture_coords: Option<&TextureCoordinates>,
 ) {
     // While this is a generic utility, it is closely tied to
     // crate::frameworks::opengles::eagl::present_renderbuffer, which handles
@@ -64,6 +114,7 @@ pub unsafe fn present_frame(
         viewport.2 as _,
         viewport.3 as _,
     );
+
     gles.ClearColor(0.0, 0.0, 0.0, 1.0);
     gles.Clear(gles11::COLOR_BUFFER_BIT | gles11::DEPTH_BUFFER_BIT | gles11::STENCIL_BUFFER_BIT);
     gles.BindBuffer(gles11::ARRAY_BUFFER, 0);
@@ -72,9 +123,14 @@ pub unsafe fn present_frame(
     ];
     gles.EnableClientState(gles11::VERTEX_ARRAY);
     gles.VertexPointer(2, gles11::FLOAT, 0, vertices.as_ptr() as *const GLvoid);
-    let tex_coords: [f32; 12] = [0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0];
+
+    let tex_coords = normalized_texture_coords.map_or(
+        TextureCoordinates::unnormalized().tex_coords.as_ptr(),
+        |coords| coords.tex_coords.as_ptr(),
+    );
+
     gles.EnableClientState(gles11::TEXTURE_COORD_ARRAY);
-    gles.TexCoordPointer(2, gles11::FLOAT, 0, tex_coords.as_ptr() as *const GLvoid);
+    gles.TexCoordPointer(2, gles11::FLOAT, 0, tex_coords as *const GLvoid);
     let matrix = Matrix::<4>::from(&rotation_matrix);
     gles.MatrixMode(gles11::TEXTURE);
     gles.LoadMatrixf(matrix.columns().as_ptr() as *const _);

--- a/src/window.rs
+++ b/src/window.rs
@@ -1058,7 +1058,7 @@ impl Window {
             );
 
             present_frame(
-                gl_ctx, viewport, matrix, /* virtual_cursor_visible_at: */ None,
+                gl_ctx, viewport, matrix, /* virtual_cursor_visible_at: */ None, None,
             );
 
             gl_ctx.DeleteTextures(1, &texture);

--- a/src/window.rs
+++ b/src/window.rs
@@ -1041,6 +1041,22 @@ impl Window {
                 gles11::LINEAR as _,
             );
 
+            // iOS and PowerVR only support NPOT texture with CLAMP_TO_EDGE
+            // It doesn't matter for texture data from an image like the
+            // splash screen, we don't want to deal with striping from
+            // NPOT to POT conversion.
+            gl_ctx.TexParameteri(
+                gles11::TEXTURE_2D,
+                gles11::TEXTURE_WRAP_S,
+                gles11::CLAMP_TO_EDGE as _,
+            );
+
+            gl_ctx.TexParameteri(
+                gles11::TEXTURE_2D,
+                gles11::TEXTURE_WRAP_T,
+                gles11::CLAMP_TO_EDGE as _,
+            );
+
             present_frame(
                 gl_ctx, viewport, matrix, /* virtual_cursor_visible_at: */ None,
             );


### PR DESCRIPTION
Fixes NPOT texture rendering

* For textures loaded from image data, set `CLAMP_TO_EDGE`
* For render buffer, set up a POT texture to copy the guest framebuffer into, then properly handle texture coordinates to only render from written parts of the POT texture.