### PR TITLE
Add input handling for analog stick, DPad

### DIFF
--- a/src/frameworks/uikit/ui_touch.rs
+++ b/src/frameworks/uikit/ui_touch.rs
@@ -143,7 +143,7 @@ fn handle_touches_down(env: &mut Environment, map: HashMap<FingerId, Coords>) {
 
         if current_touches.contains_key(&finger_id) {
             // this seems to happen only on the desktop with a single touch
-            assert_eq!(current_touches.len(), 1);
+            //assert_eq!(current_touches.len(), 1);
             log!(
                 "Warning: New touch {:?} initiated but current touch did not end yet, treating as movement.",
                 finger_id

--- a/src/frameworks/uikit/ui_touch.rs
+++ b/src/frameworks/uikit/ui_touch.rs
@@ -142,8 +142,6 @@ fn handle_touches_down(env: &mut Environment, map: HashMap<FingerId, Coords>) {
         let current_touches = &mut env.framework_state.uikit.ui_touch.current_touches;
 
         if current_touches.contains_key(&finger_id) {
-            // this seems to happen only on the desktop with a single touch
-            //assert_eq!(current_touches.len(), 1);
             log!(
                 "Warning: New touch {:?} initiated but current touch did not end yet, treating as movement.",
                 finger_id

--- a/src/options.rs
+++ b/src/options.rs
@@ -168,7 +168,7 @@ impl Options {
                 .try_into()
                 .map_err(|_| "--stick-to-touch= requires four values".to_string())?;
 
-                self.stick_to_touch = Some((nums[0], nums[1], nums[2], nums[3]));
+            self.stick_to_touch = Some((nums[0], nums[1], nums[2], nums[3]));
         } else if let Some(values) = arg.strip_prefix("--dpad-to-touch=") {
             let nums: [f32; 4] = values
                 .split(',')

--- a/src/options.rs
+++ b/src/options.rs
@@ -44,6 +44,7 @@ pub struct Options {
     pub x_tilt_offset: f32,
     pub y_tilt_offset: f32,
     pub button_to_touch: HashMap<Button, (f32, f32)>,
+    pub stick_to_touch: Option<(f32, f32, f32, f32)>,
     pub stabilize_virtual_cursor: Option<(f32, f32)>,
     pub gles1_implementation: Option<GLESImplementation>,
     pub direct_memory_access: bool,
@@ -73,6 +74,7 @@ impl Default for Options {
             x_tilt_offset: 0.0,
             y_tilt_offset: 0.0,
             button_to_touch: HashMap::new(),
+            stick_to_touch: None,
             stabilize_virtual_cursor: None,
             gles1_implementation: None,
             direct_memory_access: true,
@@ -155,6 +157,29 @@ impl Options {
                 .parse()
                 .map_err(|_| "Invalid Y co-ordinate for --button-to-touch=".to_string())?;
             self.button_to_touch.insert(button, (x, y));
+        } else if let Some(values) = arg.strip_prefix("--stick-to-touch=") {
+            let (x, rest) = values
+                .split_once(',')
+                .ok_or_else(|| "--stick-to-touch= requires four values".to_string())?;
+            let (y, rest) = rest
+                .split_once(',')
+                .ok_or_else(|| "--stick-to-touch= requires four values".to_string())?;
+            let (w, h) = rest
+                .split_once(',')
+                .ok_or_else(|| "--stick-to-touch= requires four values".to_string())?;
+            let x: f32 = x
+                .parse()
+                .map_err(|_| "Invalid first X co-ordinate for --stick-to-touch=".to_string())?;
+            let y: f32 = y
+                .parse()
+                .map_err(|_| "Invalid first Y co-ordinate for --stick-to-touch=".to_string())?;
+            let w: f32 = w
+                .parse()
+                .map_err(|_| "Invalid second X co-ordinate for --stick-to-touch=".to_string())?;
+            let h: f32 = h
+                .parse()
+                .map_err(|_| "Invalid second Y co-ordinate for --stick-to-touch=".to_string())?;
+            self.stick_to_touch = Some((x, y, w, h));
         } else if let Some(value) = arg.strip_prefix("--stabilize-virtual-cursor=") {
             let (smoothing_strength, sticky_radius) = value
                 .split_once(',')

--- a/src/options.rs
+++ b/src/options.rs
@@ -44,6 +44,7 @@ pub struct Options {
     pub x_tilt_offset: f32,
     pub y_tilt_offset: f32,
     pub button_to_touch: HashMap<Button, (f32, f32)>,
+    pub dpad_to_touch: Option<(f32, f32, f32, f32)>,
     pub stick_to_touch: Option<(f32, f32, f32, f32)>,
     pub stabilize_virtual_cursor: Option<(f32, f32)>,
     pub gles1_implementation: Option<GLESImplementation>,
@@ -74,6 +75,7 @@ impl Default for Options {
             x_tilt_offset: 0.0,
             y_tilt_offset: 0.0,
             button_to_touch: HashMap::new(),
+            dpad_to_touch: None,
             stick_to_touch: None,
             stabilize_virtual_cursor: None,
             gles1_implementation: None,
@@ -158,28 +160,25 @@ impl Options {
                 .map_err(|_| "Invalid Y co-ordinate for --button-to-touch=".to_string())?;
             self.button_to_touch.insert(button, (x, y));
         } else if let Some(values) = arg.strip_prefix("--stick-to-touch=") {
-            let (x, rest) = values
-                .split_once(',')
-                .ok_or_else(|| "--stick-to-touch= requires four values".to_string())?;
-            let (y, rest) = rest
-                .split_once(',')
-                .ok_or_else(|| "--stick-to-touch= requires four values".to_string())?;
-            let (w, h) = rest
-                .split_once(',')
-                .ok_or_else(|| "--stick-to-touch= requires four values".to_string())?;
-            let x: f32 = x
-                .parse()
-                .map_err(|_| "Invalid first X co-ordinate for --stick-to-touch=".to_string())?;
-            let y: f32 = y
-                .parse()
-                .map_err(|_| "Invalid first Y co-ordinate for --stick-to-touch=".to_string())?;
-            let w: f32 = w
-                .parse()
-                .map_err(|_| "Invalid second X co-ordinate for --stick-to-touch=".to_string())?;
-            let h: f32 = h
-                .parse()
-                .map_err(|_| "Invalid second Y co-ordinate for --stick-to-touch=".to_string())?;
-            self.stick_to_touch = Some((x, y, w, h));
+            let nums: [f32; 4] = values
+                .split(',')
+                .map(|s| s.parse::<f32>())
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| "invalid --stick-to-touch".to_string())?
+                .try_into()
+                .map_err(|_| "--stick-to-touch= requires four values".to_string())?;
+
+                self.stick_to_touch = Some((nums[0], nums[1], nums[2], nums[3]));
+        } else if let Some(values) = arg.strip_prefix("--dpad-to-touch=") {
+            let nums: [f32; 4] = values
+                .split(',')
+                .map(|s| s.parse::<f32>())
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| "invalid --dpad-to-touch".to_string())?
+                .try_into()
+                .map_err(|_| "--dpad-to-touch= requires four values".to_string())?;
+
+            self.dpad_to_touch = Some((nums[0], nums[1], nums[2], nums[3]));
         } else if let Some(value) = arg.strip_prefix("--stabilize-virtual-cursor=") {
             let (smoothing_strength, sticky_radius) = value
                 .split_once(',')

--- a/src/window.rs
+++ b/src/window.rs
@@ -523,37 +523,16 @@ impl Window {
                         && options.dpad_to_touch.is_some()
                     {
                         let Some((x, y, w, h)) = options.dpad_to_touch else {
-                            continue;
+                            unreachable!();
                         };
+
                         // Update held state
-                        match (button, &event) {
-                            (crate::options::Button::DPadLeft, E::ControllerButtonDown { .. }) => {
-                                self.dpad_state.left = true
-                            }
-                            (crate::options::Button::DPadLeft, E::ControllerButtonUp { .. }) => {
-                                self.dpad_state.left = false
-                            }
-
-                            (crate::options::Button::DPadRight, E::ControllerButtonDown { .. }) => {
-                                self.dpad_state.right = true
-                            }
-                            (crate::options::Button::DPadRight, E::ControllerButtonUp { .. }) => {
-                                self.dpad_state.right = false
-                            }
-
-                            (crate::options::Button::DPadUp, E::ControllerButtonDown { .. }) => {
-                                self.dpad_state.up = true
-                            }
-                            (crate::options::Button::DPadUp, E::ControllerButtonUp { .. }) => {
-                                self.dpad_state.up = false
-                            }
-
-                            (crate::options::Button::DPadDown, E::ControllerButtonDown { .. }) => {
-                                self.dpad_state.down = true
-                            }
-                            (crate::options::Button::DPadDown, E::ControllerButtonUp { .. }) => {
-                                self.dpad_state.down = false
-                            }
+                        let pressed = matches!(event, E::ControllerButtonDown { .. });
+                        match button {
+                            crate::options::Button::DPadLeft => self.dpad_state.left = pressed,
+                            crate::options::Button::DPadRight => self.dpad_state.right = pressed,
+                            crate::options::Button::DPadUp => self.dpad_state.up = pressed,
+                            crate::options::Button::DPadDown => self.dpad_state.down = pressed,
                             _ => unreachable!(),
                         }
 
@@ -641,7 +620,7 @@ impl Window {
                             ),
                             true,
                         );
-                        if stick_x.abs() < 0.1 && stick_y.abs() < 0.1 {
+                        if stick_x.abs() < options.deadzone && stick_y.abs() < options.deadzone {
                             if !self.stick_active {
                                 // Ignore deadzone events when stick is inactive
                                 continue;

--- a/src/window.rs
+++ b/src/window.rs
@@ -179,6 +179,7 @@ pub struct Window {
     controller_ctx: sdl2::GameControllerSubsystem,
     controllers: Vec<sdl2::controller::GameController>,
     dpad_state: DpadState,
+    stick_active: bool,
     _sensor_ctx: sdl2::SensorSubsystem,
     accelerometer: Option<sdl2::sensor::Sensor>,
     virtual_cursor_last: Option<(f32, f32, bool, bool)>,
@@ -325,6 +326,7 @@ impl Window {
                 down: false,
                 active: false,
             },
+            stick_active: false,
             _sensor_ctx: sensor_ctx,
             accelerometer,
             virtual_cursor_last: None,
@@ -625,9 +627,23 @@ impl Window {
                             true,
                         );
                         if stick_x.abs() < 0.1 && stick_y.abs() < 0.1 {
-                            Event::TouchesUp(HashMap::from([(FingerId::StickToTouch, coords)]))
+                            if !self.stick_active {
+                                // Ignore deadzone events when stick is inactive 
+                                continue;
+                            } else {
+                                // Release touch when stick returns to deadzone
+                                self.stick_active = false;
+                                Event::TouchesUp(HashMap::from([(FingerId::StickToTouch, coords)]))
+                            }
                         } else {
-                            Event::TouchesDown(HashMap::from([(FingerId::StickToTouch, coords)]))
+                            if !self.stick_active {
+                                // New touch
+                                self.stick_active = true;
+                                Event::TouchesDown(HashMap::from([(FingerId::StickToTouch, coords)]))
+                            } else {
+                                // Move existing touch
+                                Event::TouchesMove(HashMap::from([(FingerId::StickToTouch, coords)]))
+                            }
                         }
                     } else {
                         continue;

--- a/src/window.rs
+++ b/src/window.rs
@@ -77,8 +77,17 @@ pub enum FingerId {
     VirtualCursor,
     ButtonToTouch(crate::options::Button),
     StickToTouch,
+    DpadToTouch,
 }
 pub type Coords = (f32, f32);
+
+struct DpadState {
+    left: bool,
+    right: bool,
+    up: bool,
+    down: bool,
+    active: bool,
+}
 
 #[derive(Debug)]
 pub enum TextInputEvent {
@@ -169,6 +178,7 @@ pub struct Window {
     app_gl_ctx_no_longer_current: bool,
     controller_ctx: sdl2::GameControllerSubsystem,
     controllers: Vec<sdl2::controller::GameController>,
+    dpad_state: DpadState,
     _sensor_ctx: sdl2::SensorSubsystem,
     accelerometer: Option<sdl2::sensor::Sensor>,
     virtual_cursor_last: Option<(f32, f32, bool, bool)>,
@@ -308,6 +318,13 @@ impl Window {
             app_gl_ctx_no_longer_current: false,
             controller_ctx,
             controllers: Vec::new(),
+            dpad_state: DpadState {
+                left: false,
+                right: false,
+                up: false,
+                down: false,
+                active: false,
+            },
             _sensor_ctx: sensor_ctx,
             accelerometer,
             virtual_cursor_last: None,
@@ -496,25 +513,99 @@ impl Window {
                     let Some(button) = translate_button(button) else {
                         continue;
                     };
-                    let Some(&(x, y)) = options.button_to_touch.get(&button) else {
-                        continue;
-                    };
-                    match event {
-                        E::ControllerButtonUp { .. } => {
-                            let coords = transform_input_coords(self, (x, y), true);
-                            Event::TouchesUp(HashMap::from([(
-                                FingerId::ButtonToTouch(button),
-                                coords,
-                            )]))
+                    // Called whenever a DPad direction is pressed or released
+                    if (button == crate::options::Button::DPadLeft
+                        || button == crate::options::Button::DPadUp
+                        || button == crate::options::Button::DPadRight
+                        || button == crate::options::Button::DPadDown)
+                        && options.dpad_to_touch.is_some()
+                    {
+                        let Some((x, y, w, h)) = options.dpad_to_touch else {
+                            continue;
+                        };
+                        // Update held state
+                        match (button, &event) {
+                            (crate::options::Button::DPadLeft,  E::ControllerButtonDown { .. }) => self.dpad_state.left  = true,
+                            (crate::options::Button::DPadLeft,  E::ControllerButtonUp   { .. }) => self.dpad_state.left  = false,
+
+                            (crate::options::Button::DPadRight, E::ControllerButtonDown { .. }) => self.dpad_state.right = true,
+                            (crate::options::Button::DPadRight, E::ControllerButtonUp   { .. }) => self.dpad_state.right = false,
+
+                            (crate::options::Button::DPadUp,    E::ControllerButtonDown { .. }) => self.dpad_state.up    = true,
+                            (crate::options::Button::DPadUp,    E::ControllerButtonUp   { .. }) => self.dpad_state.up    = false,
+
+                            (crate::options::Button::DPadDown,  E::ControllerButtonDown { .. }) => self.dpad_state.down  = true,
+                            (crate::options::Button::DPadDown,  E::ControllerButtonUp   { .. }) => self.dpad_state.down  = false,
+                            _ => unreachable!(),
                         }
-                        E::ControllerButtonDown { .. } => {
-                            let coords = transform_input_coords(self, (x, y), true);
+
+                        // Compute center
+                        let cx = x + w * 0.5;
+                        let cy = y + h * 0.5;
+
+                        // Compute combined delta
+                        let mut dx = 0.0;
+                        let mut dy = 0.0;
+
+                        if self.dpad_state.left  { dx -= 0.5 * w; }
+                        if self.dpad_state.right { dx += 0.5 * w; }
+                        if self.dpad_state.up    { dy -= 0.5 * h; }
+                        if self.dpad_state.down  { dy += 0.5 * h; }
+
+                        // Final coords: center + movement
+                        let coords = transform_input_coords(self, (cx + dx, cy + dy), true);
+
+                        // Send TouchDown if any dpad is held, TouchUp if none
+                        let any_held =
+                            self.dpad_state.left  ||
+                            self.dpad_state.right ||
+                            self.dpad_state.up    ||
+                            self.dpad_state.down;
+
+                        if !self.dpad_state.active && any_held {
+                            // New touch
+                            self.dpad_state.active = true;
                             Event::TouchesDown(HashMap::from([(
-                                FingerId::ButtonToTouch(button),
+                                FingerId::DpadToTouch,
                                 coords,
                             )]))
+                        } else if self.dpad_state.active && any_held {
+                            // Move existing touch
+                            Event::TouchesMove(HashMap::from([(
+                                FingerId::DpadToTouch,
+                                coords,
+                            )]))
+                        } else if self.dpad_state.active && !any_held {
+                            // Release touch
+                            self.dpad_state.active = false;
+                            Event::TouchesUp(HashMap::from([(
+                                FingerId::DpadToTouch,
+                                coords,
+                            )]))
+                        } else {
+                            continue;
                         }
-                        _ => unreachable!(),
+                    } else {
+                        let Some(&(x, y)) = options.button_to_touch.get(&button) else {
+                            continue;
+                        };
+                        match event {
+                            E::ControllerButtonUp { .. } => {
+                                let coords = transform_input_coords(self, (x, y), true);
+                                Event::TouchesUp(HashMap::from([(
+                                    FingerId::ButtonToTouch(button),
+                                    coords,
+                                )]))
+                            }
+                            E::ControllerButtonDown { .. } => {
+                                let coords = transform_input_coords(self, (x, y), true);
+                                Event::TouchesDown(HashMap::from([(
+                                    FingerId::ButtonToTouch(button),
+                                    coords,
+                                )]))
+                            }
+                            _ => unreachable!(),
+                        }
                     }
                 }
                 E::ControllerAxisMotion { axis, .. } => {

--- a/src/window.rs
+++ b/src/window.rs
@@ -650,22 +650,20 @@ impl Window {
                                 self.stick_active = false;
                                 Event::TouchesUp(HashMap::from([(FingerId::StickToTouch, coords)]))
                             }
-                        } else {
-                            if !self.stick_active {
-                                // New touch
-                                self.stick_active = true;
-                                Event::TouchesDown(HashMap::from([(
-                                    FingerId::StickToTouch,
-                                    coords,
-                                )]))
-                            } else {
-                                // Move existing touch
-                                Event::TouchesMove(HashMap::from([(
-                                    FingerId::StickToTouch,
-                                    coords,
-                                )]))
-                            }
-                        }
+                        } else if !self.stick_active {
+                            // New touch
+                            self.stick_active = true;
+                            Event::TouchesDown(HashMap::from([(
+                                FingerId::StickToTouch,
+                                coords,
+                            )]))
+                         } else {
+                            // Move existing touch
+                            Event::TouchesMove(HashMap::from([(
+                                FingerId::StickToTouch,
+                                coords,
+                            )]))
+                         }
                     } else {
                         continue;
                     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -653,17 +653,11 @@ impl Window {
                         } else if !self.stick_active {
                             // New touch
                             self.stick_active = true;
-                            Event::TouchesDown(HashMap::from([(
-                                FingerId::StickToTouch,
-                                coords,
-                            )]))
-                         } else {
+                            Event::TouchesDown(HashMap::from([(FingerId::StickToTouch, coords)]))
+                        } else {
                             // Move existing touch
-                            Event::TouchesMove(HashMap::from([(
-                                FingerId::StickToTouch,
-                                coords,
-                            )]))
-                         }
+                            Event::TouchesMove(HashMap::from([(FingerId::StickToTouch, coords)]))
+                        }
                     } else {
                         continue;
                     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -76,6 +76,7 @@ pub enum FingerId {
     Touch(i64),
     VirtualCursor,
     ButtonToTouch(crate::options::Button),
+    StickToTouch,
 }
 pub type Coords = (f32, f32);
 
@@ -516,9 +517,30 @@ impl Window {
                         _ => unreachable!(),
                     }
                 }
-                E::ControllerAxisMotion { .. } => {
+                E::ControllerAxisMotion { axis, .. } => {
                     controller_updated = true;
-                    continue;
+                    let Some((x, y, w, h)) = options.stick_to_touch else {
+                        continue;
+                    };
+                    if axis == sdl2::controller::Axis::LeftX || axis == sdl2::controller::Axis::LeftY
+                    {
+                        let (stick_x, stick_y, _) = self.get_controller_stick(options, true);
+                        let coords = transform_input_coords(
+                            self,
+                            (
+                                x + ((stick_x + 1.0) / 2.0) * w,
+                                y + ((stick_y + 1.0) / 2.0) * h,
+                            ),
+                            true,
+                        );
+                        if stick_x.abs() < 0.1 && stick_y.abs() < 0.1 {
+                            Event::TouchesUp(HashMap::from([(FingerId::StickToTouch, coords)]))
+                        } else {
+                            Event::TouchesDown(HashMap::from([(FingerId::StickToTouch, coords)]))
+                        }
+                    } else {
+                        continue;
+                    }
                 }
                 E::AppWillEnterBackground { .. } => {
                     log!("Received app-will-resign-active event.");

--- a/src/window.rs
+++ b/src/window.rs
@@ -527,17 +527,33 @@ impl Window {
                         };
                         // Update held state
                         match (button, &event) {
-                            (crate::options::Button::DPadLeft,  E::ControllerButtonDown { .. }) => self.dpad_state.left  = true,
-                            (crate::options::Button::DPadLeft,  E::ControllerButtonUp   { .. }) => self.dpad_state.left  = false,
+                            (crate::options::Button::DPadLeft, E::ControllerButtonDown { .. }) => {
+                                self.dpad_state.left = true
+                            }
+                            (crate::options::Button::DPadLeft, E::ControllerButtonUp { .. }) => {
+                                self.dpad_state.left = false
+                            }
 
-                            (crate::options::Button::DPadRight, E::ControllerButtonDown { .. }) => self.dpad_state.right = true,
-                            (crate::options::Button::DPadRight, E::ControllerButtonUp   { .. }) => self.dpad_state.right = false,
+                            (crate::options::Button::DPadRight, E::ControllerButtonDown { .. }) => {
+                                self.dpad_state.right = true
+                            }
+                            (crate::options::Button::DPadRight, E::ControllerButtonUp { .. }) => {
+                                self.dpad_state.right = false
+                            }
 
-                            (crate::options::Button::DPadUp,    E::ControllerButtonDown { .. }) => self.dpad_state.up    = true,
-                            (crate::options::Button::DPadUp,    E::ControllerButtonUp   { .. }) => self.dpad_state.up    = false,
+                            (crate::options::Button::DPadUp, E::ControllerButtonDown { .. }) => {
+                                self.dpad_state.up = true
+                            }
+                            (crate::options::Button::DPadUp, E::ControllerButtonUp { .. }) => {
+                                self.dpad_state.up = false
+                            }
 
-                            (crate::options::Button::DPadDown,  E::ControllerButtonDown { .. }) => self.dpad_state.down  = true,
-                            (crate::options::Button::DPadDown,  E::ControllerButtonUp   { .. }) => self.dpad_state.down  = false,
+                            (crate::options::Button::DPadDown, E::ControllerButtonDown { .. }) => {
+                                self.dpad_state.down = true
+                            }
+                            (crate::options::Button::DPadDown, E::ControllerButtonUp { .. }) => {
+                                self.dpad_state.down = false
+                            }
                             _ => unreachable!(),
                         }
 
@@ -549,41 +565,39 @@ impl Window {
                         let mut dx = 0.0;
                         let mut dy = 0.0;
 
-                        if self.dpad_state.left  { dx -= 0.5 * w; }
-                        if self.dpad_state.right { dx += 0.5 * w; }
-                        if self.dpad_state.up    { dy -= 0.5 * h; }
-                        if self.dpad_state.down  { dy += 0.5 * h; }
+                        if self.dpad_state.left {
+                            dx -= 0.5 * w;
+                        }
+                        if self.dpad_state.right {
+                            dx += 0.5 * w;
+                        }
+                        if self.dpad_state.up {
+                            dy -= 0.5 * h;
+                        }
+                        if self.dpad_state.down {
+                            dy += 0.5 * h;
+                        }
 
                         // Final coords: center + movement
                         let coords = transform_input_coords(self, (cx + dx, cy + dy), true);
 
                         // Send TouchDown if any dpad is held, TouchUp if none
-                        let any_held =
-                            self.dpad_state.left  ||
-                            self.dpad_state.right ||
-                            self.dpad_state.up    ||
-                            self.dpad_state.down;
+                        let any_held = self.dpad_state.left
+                            || self.dpad_state.right
+                            || self.dpad_state.up
+                            || self.dpad_state.down;
 
                         if !self.dpad_state.active && any_held {
                             // New touch
                             self.dpad_state.active = true;
-                            Event::TouchesDown(HashMap::from([(
-                                FingerId::DpadToTouch,
-                                coords,
-                            )]))
+                            Event::TouchesDown(HashMap::from([(FingerId::DpadToTouch, coords)]))
                         } else if self.dpad_state.active && any_held {
                             // Move existing touch
-                            Event::TouchesMove(HashMap::from([(
-                                FingerId::DpadToTouch,
-                                coords,
-                            )]))
+                            Event::TouchesMove(HashMap::from([(FingerId::DpadToTouch, coords)]))
                         } else if self.dpad_state.active && !any_held {
                             // Release touch
                             self.dpad_state.active = false;
-                            Event::TouchesUp(HashMap::from([(
-                                FingerId::DpadToTouch,
-                                coords,
-                            )]))
+                            Event::TouchesUp(HashMap::from([(FingerId::DpadToTouch, coords)]))
                         } else {
                             continue;
                         }
@@ -615,7 +629,8 @@ impl Window {
                     let Some((x, y, w, h)) = options.stick_to_touch else {
                         continue;
                     };
-                    if axis == sdl2::controller::Axis::LeftX || axis == sdl2::controller::Axis::LeftY
+                    if axis == sdl2::controller::Axis::LeftX
+                        || axis == sdl2::controller::Axis::LeftY
                     {
                         let (stick_x, stick_y, _) = self.get_controller_stick(options, true);
                         let coords = transform_input_coords(
@@ -628,7 +643,7 @@ impl Window {
                         );
                         if stick_x.abs() < 0.1 && stick_y.abs() < 0.1 {
                             if !self.stick_active {
-                                // Ignore deadzone events when stick is inactive 
+                                // Ignore deadzone events when stick is inactive
                                 continue;
                             } else {
                                 // Release touch when stick returns to deadzone
@@ -639,10 +654,16 @@ impl Window {
                             if !self.stick_active {
                                 // New touch
                                 self.stick_active = true;
-                                Event::TouchesDown(HashMap::from([(FingerId::StickToTouch, coords)]))
+                                Event::TouchesDown(HashMap::from([(
+                                    FingerId::StickToTouch,
+                                    coords,
+                                )]))
                             } else {
                                 // Move existing touch
-                                Event::TouchesMove(HashMap::from([(FingerId::StickToTouch, coords)]))
+                                Event::TouchesMove(HashMap::from([(
+                                    FingerId::StickToTouch,
+                                    coords,
+                                )]))
                             }
                         }
                     } else {

--- a/touchHLE_default_options.txt
+++ b/touchHLE_default_options.txt
@@ -174,3 +174,7 @@ com.pangea.nano2: --ignore-gl-errors
 
 # Bugdom 2
 com.pangea.bug2: --ignore-gl-errors
+
+# Rayman 2
+# Stick = Move, A = Jump, X = Shoot/Skip cutscene, Y = First-person, B = Dive
+com.gameloft.Rayman2: --stick-to-touch=22,210,90,100 --button-to-touch=A,376,280 --button-to-touch=X,435,220 --button-to-touch=Y,22,88 --button-to-touch=B,448,144 --button-to-touch=Start,16,16

--- a/touchHLE_default_options.txt
+++ b/touchHLE_default_options.txt
@@ -82,7 +82,7 @@ com.darxun.motoracinggp: --landscape-right --button-to-touch=A,25,295 --button-t
 com.bestsungame.warriornationblade:  --button-to-touch=DPadLeft,50,285 --button-to-touch=DPadRight,120,285 --button-to-touch=A,430,260 --button-to-touch=B,440,185 --button-to-touch=X,360,280 --button-to-touch=Y,230,270 --button-to-touch=LeftShoulder,270,30 --button-to-touch=Start,460,20
 
 # Resident Evil 4
-jp.co.capcom.res4: --landscape-left --stabilize-virtual-cursor=0.1,10 --button-to-touch=A,430,280 --button-to-touch=B,440,200 --button-to-touch=X,360,200 --button-to-touch=Y,440,150 --button-to-touch=DPadLeft,25,247 --button-to-touch=DPadUp,72,200 --button-to-touch=DPadRight,120,247 --button-to-touch=DPadDown,72,300
+jp.co.capcom.res4: --landscape-left --stabilize-virtual-cursor=0.1,10 --button-to-touch=A,430,280 --button-to-touch=B,440,200 --button-to-touch=X,360,200 --button-to-touch=Y,440,150 --button-to-touch=DPadLeft,25,247 --button-to-touch=DPadUp,72,200 --button-to-touch=DPadRight,120,247 --button-to-touch=DPadDown,72,300 --stick-to-touch=25,200,95,100
 
 # Earthworm Jim
 # Up/Down/Left/Right = Move, A = Jump, B = Whip, X = Fire

--- a/touchHLE_default_options.txt
+++ b/touchHLE_default_options.txt
@@ -82,12 +82,12 @@ com.darxun.motoracinggp: --landscape-right --button-to-touch=A,25,295 --button-t
 com.bestsungame.warriornationblade:  --button-to-touch=DPadLeft,50,285 --button-to-touch=DPadRight,120,285 --button-to-touch=A,430,260 --button-to-touch=B,440,185 --button-to-touch=X,360,280 --button-to-touch=Y,230,270 --button-to-touch=LeftShoulder,270,30 --button-to-touch=Start,460,20
 
 # Resident Evil 4
-jp.co.capcom.res4: --landscape-left --stabilize-virtual-cursor=0.1,10 --button-to-touch=A,430,280 --button-to-touch=B,440,200 --button-to-touch=X,360,200 --button-to-touch=Y,440,150 --button-to-touch=DPadLeft,25,247 --button-to-touch=DPadUp,72,200 --button-to-touch=DPadRight,120,247 --button-to-touch=DPadDown,72,300 --stick-to-touch=25,200,95,100
+jp.co.capcom.res4: --landscape-left --stabilize-virtual-cursor=0.1,10 --button-to-touch=A,430,280 --button-to-touch=B,440,200 --button-to-touch=X,360,200 --button-to-touch=Y,440,150 --dpad-to-touch=25,200,95,100 --stick-to-touch=25,200,95,100
 
 # Earthworm Jim
-# Up/Down/Left/Right = Move, A = Jump, B = Whip, X = Fire
+# Dpad = Move, A = Jump, B = Whip, X = Fire
 # Note: "Force composition" flag is needed to fix broken render in the level select screen.
-com.gameloft.Earthworm: --landscape-left --button-to-touch=DPadUp,72,194 --button-to-touch=DPadDown,72,278 --button-to-touch=DPadLeft,30,238 --button-to-touch=DPadRight,110,238 --button-to-touch=A,442,284 --button-to-touch=X,378,248 --button-to-touch=B,442,212 --button-to-touch=Start,448,32 --force-composition
+com.gameloft.Earthworm: --landscape-left --dpad-to-touch=30,194,80,84 --button-to-touch=A,442,284 --button-to-touch=X,378,248 --button-to-touch=B,442,212 --button-to-touch=Start,448,32 --force-composition
 
 # TV Show King
 com.gameloft.TVSK: --landscape-right


### PR DESCRIPTION
This PR adds two new options to improve game input on controllers:

**--stick-to-touch=x,y,w,h** defines a region on the screen in which a touch with FingerId::StickToTouch slides around relative to the left analog stick. This is useful for games like Resident Evil 4 mobile edition and Rayman 2 which use analog movement, which were previously very stiff to control.

**--dpad-to-touch=x,y,w,h** defines a region on the screen in which a touch with FingerId::DpadToTouch mimics an 8-directional pad. This is useful for 2D games where diagonals are used.

In implementing these I added a little bit of controller state to the Window class. I also removed a check in **ui_touch.rs** that makes sure only one touch is happening at a time, which I don't think is needed anymore?

I'm opening this PR here for thoughts on the implementation and for others to test. A few quirks still exist such as how this should play with the accelerometer that's already mapped to the left stick, and I don't have access to any games that would benefit from DPad like Earthworm Jim. I can open on Gerrit if there are no major problems/disagreements with adding this.

https://github.com/user-attachments/assets/e477fc60-69b8-4feb-b5d2-edb20a49feb9

<img width="960" height="640" alt="image" src="https://github.com/user-attachments/assets/daa6dd07-7dc9-420c-bdc6-20d2aa7d0107" />

Related: #325 #400 #500 
