### PR TITLE
Family Guy Uncensored

### DIFF
--- a/src/frameworks/audio_toolbox/audio_services.rs
+++ b/src/frameworks/audio_toolbox/audio_services.rs
@@ -18,6 +18,19 @@ type SystemSoundID = u32;
 const kAudioServicesUnsupportedPropertyError: OSStatus = fourcc(b"pty?") as _;
 const kSystemSoundID_Vibrate: SystemSoundID = 0x00000FFF;
 
+fn AudioServicesAddSystemSoundCompletion(
+    _env: &mut Environment,
+    _in_system_sound_id: SystemSoundID,
+    _in_run_loop: crate::mem::ConstVoidPtr,
+    _in_run_loop_mode: crate::mem::ConstVoidPtr,
+    _in_completion_proc: crate::mem::ConstVoidPtr,
+    _in_client_data: crate::mem::ConstVoidPtr,
+) -> OSStatus {
+    assert_eq!(_in_system_sound_id, kSystemSoundID_Vibrate);
+    println!("TODO: vibration (AudioServicesAddSystemSoundCompletion)");
+    OSStatus::from(0)
+}
+
 fn AudioServicesGetProperty(
     _env: &mut Environment,
     in_property_id: AudioServicesPropertyID,
@@ -41,7 +54,17 @@ fn AudioServicesPlaySystemSound(_env: &mut Environment, in_system_sound_id: Syst
     // TODO: implement other system sounds
 }
 
+fn AudioServicesRemoveSystemSoundCompletion(
+    _env: &mut Environment,
+    _in_system_sound_id: SystemSoundID,
+) {
+    assert_eq!(_in_system_sound_id, kSystemSoundID_Vibrate);
+    println!("TODO: vibration (AudioServicesRemoveSystemSoundCompletion)");
+}
+
 pub const FUNCTIONS: FunctionExports = &[
+    export_c_func!(AudioServicesAddSystemSoundCompletion(_, _, _, _, _)),
     export_c_func!(AudioServicesGetProperty(_, _, _, _, _)),
     export_c_func!(AudioServicesPlaySystemSound(_)),
+    export_c_func!(AudioServicesRemoveSystemSoundCompletion(_)),
 ];

--- a/src/frameworks/core_foundation.rs
+++ b/src/frameworks/core_foundation.rs
@@ -21,6 +21,7 @@ pub mod cf_array;
 pub mod cf_bundle;
 pub mod cf_data;
 pub mod cf_dictionary;
+pub mod cf_host;
 pub mod cf_locale;
 pub mod cf_number;
 pub mod cf_preferences;
@@ -53,6 +54,7 @@ pub const DYLIB: crate::dyld::HostDylib = crate::dyld::HostDylib {
         cf_bundle::FUNCTIONS,
         cf_socket::FUNCTIONS,
         cf_data::FUNCTIONS,
+        cf_host::FUNCTIONS,
         cf_locale::FUNCTIONS,
         cf_number::FUNCTIONS,
         cf_preferences::FUNCTIONS,

--- a/src/frameworks/core_foundation/cf_host.rs
+++ b/src/frameworks/core_foundation/cf_host.rs
@@ -1,0 +1,23 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+//! `CFHost`. Currently there is no actual support for this type.
+
+use super::cf_string::CFStringRef;
+use super::CFTypeRef;
+use crate::dyld::{export_c_func, FunctionExports};
+use crate::mem::Ptr;
+use crate::Environment;
+
+fn CFHostCreateWithName(
+    _env: &mut Environment,
+    _allocator: CFTypeRef,
+    _host_name: CFStringRef,
+) -> CFTypeRef {
+    println!("CFHostCreateWithName called: returning stubbed null pointer");
+    Ptr::null()
+}
+
+pub const FUNCTIONS: FunctionExports = &[export_c_func!(CFHostCreateWithName(_, _))];

--- a/src/frameworks/foundation/ns_string.rs
+++ b/src/frameworks/foundation/ns_string.rs
@@ -263,7 +263,7 @@ pub fn with_format(env: &mut Environment, format: id, args: VaList) -> String {
         args,
     );
     // TODO: what if it's not valid UTF-8?
-    String::from_utf8(res).unwrap()
+    String::from_utf8_lossy(&res).into_owned()
 }
 
 pub fn from_rust_ordering(ordering: std::cmp::Ordering) -> NSComparisonResult {
@@ -1588,10 +1588,10 @@ pub fn register_constant_strings(bin: &MachO, mem: &mut Mem, objc: &mut ObjC) {
         // See https://lists.llvm.org/pipermail/cfe-dev/2008-August/002518.html
         let (host_object, class_name) = if flags == 0x7C8 {
             // ASCII
-            let decoded = std::str::from_utf8(mem.bytes_at(bytes, length)).unwrap();
+            let decoded = String::from_utf8_lossy(mem.bytes_at(bytes, length)).into_owned();
 
             (
-                StringHostObject::Utf8(Cow::Owned(String::from(decoded))),
+                StringHostObject::Utf8(Cow::Owned(decoded)),
                 "_touchHLE_NSString_CFConstantString_UTF8",
             )
         } else if flags == 0x7D0 {

--- a/src/frameworks/opengles.rs
+++ b/src/frameworks/opengles.rs
@@ -21,7 +21,7 @@ pub const DYLIB: crate::dyld::HostDylib = crate::dyld::HostDylib {
     aliases: &[],
     class_exports: &[eagl::CLASSES],
     constant_exports: &[eagl::CONSTANTS],
-    function_exports: &[gles_guest::FUNCTIONS],
+    function_exports: &[gles_guest::FUNCTIONS, eagl::FUNCTIONS],
 };
 
 #[derive(Default)]

--- a/src/frameworks/opengles/eagl.rs
+++ b/src/frameworks/opengles/eagl.rs
@@ -5,7 +5,7 @@
  */
 //! EAGL.
 
-use crate::dyld::{ConstantExports, HostConstant};
+use crate::dyld::{export_c_func, ConstantExports, FunctionExports, HostConstant};
 use crate::frameworks::core_animation::ca_eagl_layer::{
     find_fullscreen_eagl_layer, get_pixels_vec_for_presenting, present_pixels,
 };
@@ -19,6 +19,7 @@ use crate::mem::MutPtr;
 use crate::objc::{id, msg, nil, objc_classes, release, retain, ClassExports, HostObject};
 use crate::options::Options;
 use crate::window::Window;
+use crate::Environment;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -736,3 +737,23 @@ unsafe fn present_renderbuffer(gles: &mut dyn GLES, window: &mut Window) {
 
     //{ let err = gl21::GetError(); if err != 0 { panic!("{:#x}", err); } }
 }
+
+pub fn EAGLGetVersion(env: &mut Environment, major: MutPtr<u32>, minor: MutPtr<u32>) {
+    let version_major: u32 = 1;
+    let version_minor: u32 = 1;
+
+    if !major.is_null() {
+        env.mem.write(major, version_major);
+    }
+    if !minor.is_null() {
+        env.mem.write(minor, version_minor);
+    }
+
+    log!(
+        "EAGLGetVersion called: major={}, minor={}",
+        version_major,
+        version_minor
+    );
+}
+
+pub const FUNCTIONS: FunctionExports = &[export_c_func!(EAGLGetVersion(_, _))];

--- a/src/frameworks/uikit/ui_view.rs
+++ b/src/frameworks/uikit/ui_view.rs
@@ -657,7 +657,9 @@ pub const CLASSES: ClassExports = objc_classes! {
                  toView:(id)other { // UIView*
     if other == nil {
         let window: id = msg![env; this window];
-        assert!(window != nil);
+        if window == nil {
+          return point;
+        }
         return msg![env; this convertPoint:point toView:window]
     }
     let this_layer = env.objc.borrow::<UIViewHostObject>(this).layer;


### PR DESCRIPTION
Adds the following needed to get Family Guy Uncensored (com.glu.famguy, com.glu.famguy-free) to boot:

- `AudioServicesAddSystemSoundCompletion` (stubbed)
- `AudioServicesRemoveSystemSoundCompletion` (stubbed)
- `CFHostCreateWithName` (stubbed)
- `EAGLGetVersion` (provide major=1,minor=1 for GLES1.1)

Also fixes a crash with a string in the game having malformed UTF-8 (do a lossy copy), and another crash where it's unable to find the top-level window when translating coordinates (return the same point)

Unfortunately the game seems to run perfect but has severe graphical corruption on both GLES1.1 and GL2, even for the very simple opening screens. The textures are indeed being uploaded with TexImage2D with valid formats but they never show up (bad coords?)

<img width="320" height="240" alt="1" src="https://github.com/user-attachments/assets/f1361ba8-b01d-433b-bb42-234005e58621" />
<img width="320" height="240" alt="1c" src="https://github.com/user-attachments/assets/18a8afa1-7f7a-47fe-909b-8aae8e575ae1" />
<img width="320" height="240" alt="2" src="https://github.com/user-attachments/assets/7f12621f-7046-46ea-b8c6-be6cbc35c817" />
<img width="320" height="240" alt="2c" src="https://github.com/user-attachments/assets/e93eda96-31a8-476e-871e-5bef1f3ba411" />
<img width="320" height="240" alt="3" src="https://github.com/user-attachments/assets/1c50a955-9df1-4253-a682-82b3486408e4" />
<img width="320" height="240" alt="3c" src="https://github.com/user-attachments/assets/a3cc01c1-1a85-46a1-b1e9-22f58ddc1cbb" />

"Would you like to enable sound" screen:
```
glViewport(x: 0, y: 0, width: 320, height: 480)
glMatrixMode(mode: 0x1701)
glLoadIdentity()
glRotatex(angle: -5898240, x: 0, y: 0, z: 65536)
glMatrixMode(mode: 0x1702)
glLoadIdentity()
glScalex(x: 64, y: 64, z: 65536)
glMatrixMode(mode: 0x1700)
glLoadIdentity()
glActiveTexture(texture: 0x84c0)
glClientActiveTexture(0x84c0)
glDisableClientState(0x8078)
glDisableClientState(0x8076)
glEnableClientState(0x8074)
glDisableClientState(0x8078)
glEnableClientState(0x8078)
glBindTexture(target: 0xde1, texture: 10)
glVertexPointer(size: 2, type_: 0x1402, stride: 8, pointer: 0x3756304c)
  translated pointer: 0x7f5b88d9d05c
glTexCoordPointer(size: 2, type_: 0x1402, stride: 8, pointer: 0x37563050)
  translated pointer: 0x7f5b88d9d060
glDrawElements(mode: 0x4, count: 90, type_: 0x1403, indices: 0x375637cc)
glVertexPointer(size: 2, type_: 0x1402, stride: 8, pointer: 0x375638d8)
  translated pointer: 0x7f5b88d9d8e8
glTexCoordPointer(size: 2, type_: 0x1402, stride: 8, pointer: 0x375638dc)
  translated pointer: 0x7f5b88d9d8ec
glDrawElements(mode: 0x4, count: 30, type_: 0x1403, indices: 0x37564058)
```

FOX logo:
```
glPushMatrix()
glTranslatex(x: 0, y: 0, z: 0)
glPushMatrix()
glTranslatex(x: 0, y: 0, z: 0)
glPushMatrix()
glTranslatex(x: 0, y: 0, z: 0)
glDisableClientState(0x8078)
glVertexPointer(size: 2, type_: 0x1402, stride: 4, pointer: 0x3750a000)
  translated pointer: 0x7f3c51b44010
glDrawArrays(mode: 0x5, first: 0, count: 4)
glPushMatrix()
glTranslatex(x: 0, y: 0, z: 0)
glDisableClientState(0x8078)
glVertexPointer(size: 2, type_: 0x1402, stride: 4, pointer: 0x3750a000)
  translated pointer: 0x7f3c51b44010
glDrawArrays(mode: 0x5, first: 0, count: 4)
glPushMatrix()
glTranslatex(x: 0, y: 0, z: 0)
glPushMatrix()
glTranslatex(x: 0, y: 0, z: 0)
glDisableClientState(0x8078)
glVertexPointer(size: 2, type_: 0x1402, stride: 4, pointer: 0x3750a000)
  translated pointer: 0x7f3c51b44010
glDrawArrays(mode: 0x5, first: 0, count: 4)
glPushMatrix()
glTranslatex(x: 0, y: 0, z: 0)
glPopMatrix()
glPopMatrix()
glPopMatrix()
glPopMatrix()
glPopMatrix()
glPushMatrix()
glTranslatex(x: 5898240, y: 6029312, z: 0)
glDisableClientState(0x8078)
glVertexPointer(size: 2, type_: 0x1402, stride: 4, pointer: 0x3750a000)
  translated pointer: 0x7f3c51b44010
glDrawArrays(mode: 0x5, first: 0, count: 4)
glPushMatrix()
glTranslatex(x: 0, y: 0, z: 0)
glPopMatrix()
glPopMatrix()
glPushMatrix()
glTranslatex(x: 0, y: 20971520, z: 0)
glDisableClientState(0x8078)
glVertexPointer(size: 2, type_: 0x1402, stride: 4, pointer: 0x3750a000)
  translated pointer: 0x7f3c51b44010
glDrawArrays(mode: 0x5, first: 0, count: 4)
glPopMatrix()
glPopMatrix()
glPopMatrix()
```

Opening not necessarily to get merged right now but in case anyone has any ideas

Change-Id: Id2827e7dfdfeb182fa3cf8dc57cfe54864df6432