### PR TITLE
Help "Cause of Death" boot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,6 +862,7 @@ dependencies = [
  "hound",
  "mach_object",
  "md5",
+ "owned_ttf_parser",
  "plist",
  "quick-xml",
  "rusttype",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,8 @@ mach_object = "0.1.17"
 plist = "1.8.0"
 zip = { version = "0.6.4", default-features = false, features = ["deflate"] }
 rusttype = "0.9.3"
-# While most Symphonia codecs are (likely) unpatented/have freely licenseable 
+owned_ttf_parser = "0.15.2"
+# While most Symphonia codecs are (likely) unpatented/have freely licenseable
 # patents as of 2024, all of the AAC profiles except AAC-LC (likely) have 
 # active patent claims. The "aac" feature only enables AAC-LC, so it's should 
 # be ok.

--- a/src/abi.rs
+++ b/src/abi.rs
@@ -180,6 +180,9 @@ impl_CallFromGuest!(0 => P0, 1 => P1, 2 => P2, 3 => P3, 4 => P4, 5 => P5);
 impl_CallFromGuest!(0 => P0, 1 => P1, 2 => P2, 3 => P3, 4 => P4, 5 => P5, 6 => P6);
 impl_CallFromGuest!(0 => P0, 1 => P1, 2 => P2, 3 => P3, 4 => P4, 5 => P5, 6 => P6, 7 => P7);
 impl_CallFromGuest!(0 => P0, 1 => P1, 2 => P2, 3 => P3, 4 => P4, 5 => P5, 6 => P6, 7 => P7, 8 => P8);
+impl_CallFromGuest!(0 => P0, 1 => P1, 2 => P2, 3 => P3, 4 => P4, 5 => P5, 6 => P6, 7 => P7, 8 => P8, 9 => P9);
+impl_CallFromGuest!(0 => P0, 1 => P1, 2 => P2, 3 => P3, 4 => P4, 5 => P5, 6 => P6, 7 => P7, 8 => P8, 9 => P9, 10 => P10);
+impl_CallFromGuest!(0 => P0, 1 => P1, 2 => P2, 3 => P3, 4 => P4, 5 => P5, 6 => P6, 7 => P7, 8 => P8, 9 => P9, 10 => P10, 11 => P11);
 
 /// This trait represents a guest or host function that can be called from host
 /// code, but using the guest ABI. See [CallFromGuest], which this is the

--- a/src/dyld.rs
+++ b/src/dyld.rs
@@ -26,7 +26,7 @@ use crate::cpu::Cpu;
 use crate::frameworks::foundation::ns_string;
 use crate::mach_o::{MachO, SectionType};
 use crate::mem::{ConstVoidPtr, GuestUSize, Mem, MutPtr, Ptr};
-use crate::objc::{nil, ClassExports, ObjC};
+use crate::objc::{nil, ClassExports, HostIMP, ObjC};
 use crate::Environment;
 use std::collections::HashMap;
 
@@ -222,12 +222,28 @@ fn write_return_to_host_routine(mem: &mut Mem, svc: u32) -> GuestFunction {
     assert!(!ptr.is_thumb());
     ptr
 }
+
+
+pub enum HostFn {
+    Function(HostFunction),
+    Imp(&'static dyn HostIMP),
+}
+
+impl Clone for HostFn {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl Copy for HostFn {
+}
+
 pub struct Dyld {
     /// List of host functions that have been "linked" and had SVCs assigned.
     ///
     /// The `&'static str` part here is purely for debugging and could be
     /// removed in release builds if it's ever necessary.
-    linked_host_functions: Vec<(&'static str, HostFunction)>,
+    linked_host_functions: Vec<(&'static str, HostFn)>,
     return_to_host_routine: Option<GuestFunction>,
     thread_exit_routine: Option<GuestFunction>,
     constants_to_link_later: Vec<(MutPtr<ConstVoidPtr>, &'static HostConstant)>,
@@ -638,10 +654,10 @@ impl Dyld {
         cpu: &mut Cpu,
         svc_pc: u32,
         svc: u32,
-    ) -> Option<HostFunction> {
+    ) -> Option<HostFn> {
         match svc {
             Self::SVC_LAZY_LINK | Self::SVC_LAZY_LINK_RET_FLAG => {
-                self.do_lazy_link(bins, mem, cpu, svc_pc)
+                self.do_lazy_link(bins, mem, cpu, svc_pc).map(HostFn::Function)
             }
             Self::SVC_THREAD_EXIT | Self::SVC_RETURN_TO_HOST => unreachable!(), // don't handle here
             Self::SVC_LINKED_FUNCTIONS_BASE.. => {
@@ -769,7 +785,7 @@ impl Dyld {
                 assert!(svc < Self::SVC_LAZY_LINK_RET_FLAG);
                 svc |= Self::SVC_LAZY_LINK_RET_FLAG;
             }
-            self.linked_host_functions.push((symbol, f));
+            self.linked_host_functions.push((symbol, HostFn::Function(f)));
 
             // Rewrite stub function to call this host function
             let stub_function_ptr: MutPtr<u32> = Ptr::from_bits(svc_pc);
@@ -856,9 +872,29 @@ impl Dyld {
         // Allocate an SVC ID for this host function
         let idx: u32 = self.linked_host_functions.len().try_into().unwrap();
         let svc = idx + Self::SVC_LINKED_FUNCTIONS_BASE;
-        self.linked_host_functions.push((symbol, f));
+        self.linked_host_functions.push((symbol, HostFn::Function(f)));
 
         // Create guest function to call this host function
+        let function_ptr = mem.alloc(8);
+        let function_ptr: MutPtr<u32> = function_ptr.cast();
+        mem.write(function_ptr + 0, encode_a32_svc(svc));
+        mem.write(function_ptr + 1, encode_a32_ret());
+
+        GuestFunction::from_addr_with_thumb_bit(function_ptr.to_bits())
+    }
+
+    pub fn create_guest_hostimp(
+        &mut self,
+        mem: &mut Mem,
+        symbol: &'static str,
+        f: &'static dyn HostIMP,
+    ) -> GuestFunction {
+        // Allocate an SVC ID for this host implementation
+        let idx: u32 = self.linked_host_functions.len().try_into().unwrap();
+        let svc = idx + Self::SVC_LINKED_FUNCTIONS_BASE;
+        self.linked_host_functions.push((symbol, HostFn::Imp(f)));
+
+        // Create guest function to call this host implementation
         let function_ptr = mem.alloc(8);
         let function_ptr: MutPtr<u32> = function_ptr.cast();
         mem.write(function_ptr + 0, encode_a32_svc(svc));

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -23,6 +23,7 @@ use std::time::{Duration, Instant};
 
 use crate::libc::pthread::cond::pthread_cond_t;
 pub use mutex::{MutexId, MutexType, PTHREAD_MUTEX_DEFAULT};
+use crate::dyld::HostFn;
 
 /// Index into the [Vec] of threads. Thread 0 is always the main thread.
 pub type ThreadId = usize;
@@ -1030,7 +1031,10 @@ impl Environment {
                             let was_in_host_function =
                                 self.threads[self.current_thread].in_host_function;
                             self.threads[self.current_thread].in_host_function = true;
-                            f.call_from_guest(self);
+                            match f {
+                                HostFn::Function(f) => {f.call_from_guest(self)}
+                                HostFn::Imp(f) => {f.call_from_guest(self)}
+                            }
                             self.threads[self.current_thread].in_host_function =
                                 was_in_host_function;
 

--- a/src/font.rs
+++ b/src/font.rs
@@ -16,9 +16,11 @@
 use crate::paths;
 use rusttype::{Point, Scale};
 use std::io::Read;
+use owned_ttf_parser::{AsFaceRef, GlyphId, Rect, Tag};
 
 pub struct Font {
     font: rusttype::Font<'static>,
+    inner_font: owned_ttf_parser::OwnedFace,
 }
 
 pub enum TextAlignment {
@@ -74,15 +76,20 @@ impl Font {
             .and_then(|mut f| f.get().read_to_end(&mut bytes).map_err(|e| e.to_string()))
         {
             panic!(
-                "Couldn't read bundled font file {path:?}: {e}. Perhaps the directory is missing?"
+                "Couldn't read bundled font file {:?}: {}. Perhaps the directory is missing?",
+                path, e
             );
         }
 
-        let Some(font) = rusttype::Font::try_from_vec(bytes) else {
-            panic!("Couldn't parse bundled font file {path:?}. This probably means the file is corrupt. Try re-downloading it.");
+        let Some(font) = rusttype::Font::try_from_vec(bytes.clone()) else {
+            panic!("Couldn't parse bundled font file {:?}. This probably means the file is corrupt. Try re-downloading it.", path);
         };
 
-        Font { font }
+        let Ok(inner_font) = owned_ttf_parser::OwnedFace::from_vec(bytes, 0) else {
+            panic!("Couldn't parse bundled font file {:?}. This probably means the file is corrupt. Try re-downloading it.", path);
+        };
+
+        Font { font, inner_font }
     }
 
     pub fn mono_regular() -> Font {
@@ -315,6 +322,45 @@ impl Font {
 
         (width, height)
     }
+    
+    pub fn get_raw_table(&self, tag: u32) -> Vec<u8> {
+        let tag = Tag::from_bytes_lossy(&tag.to_be_bytes());
+        self.inner_font.as_face_ref().table_data(tag).unwrap().to_vec()
+    }
+    
+    pub fn name(&self) -> String {
+        String::from_utf8(self.inner_font.as_face_ref().names().get(0).unwrap().name.to_vec()).unwrap()
+    }
+
+    pub fn glyph_size(&self, glyph: GlyphId) -> Rect {
+        self.inner_font.as_face_ref().glyph_bounding_box(glyph).or_else(|| {
+            self.inner_font.as_face_ref().glyph_bounding_box(self.get_glyph('a').unwrap())
+        }).unwrap()
+    }
+
+    pub fn get_glyph(&self, char: char) -> Option<GlyphId> {
+        self.inner_font.as_face_ref().glyph_index(char)
+    }
+
+    pub fn advance_unscaled(&self, glyph_id: u16) -> i32 {
+        self.inner_font.as_face_ref().glyph_hor_advance(GlyphId(glyph_id)).unwrap() as i32
+    }
+
+    pub fn units_per_em(&self) -> u16 {
+        self.inner_font.as_face_ref().units_per_em()
+    }
+
+    pub fn ascent_unscaled(&self) -> i32 {
+        self.inner_font.as_face_ref().ascender() as i32
+    }
+
+    pub fn descent_unscaled(&self) -> i32 {
+        self.inner_font.as_face_ref().descender() as i32
+    }
+
+    pub fn cap_height(&self) -> i32 {
+        self.inner_font.as_face_ref().height() as i32
+    }
 
     /// Draw text. Calls the provided callback for each glyph that is to be
     /// drawn. Assumes y starts at the bottom-left corner and points upwards.
@@ -401,6 +447,85 @@ impl Font {
                 draw_glyph(raster_glyph);
             }
             line_y += line_height + line_gap;
+        }
+    }
+    
+    /// Draw glyph. Calls the provided callback for each glyph that is to be
+    /// drawn. Assumes y starts at the bottom-left corner and points upwards.
+    pub fn draw_glyphs<F: FnMut(RasterGlyph)>(
+        &self,
+        font_size: f32,
+        glyphs: &[GlyphId],
+        origin: (f32, f32),
+        wrap: Option<(f32, WrapMode)>,
+        _alignment: TextAlignment,
+        mut draw_glyph: F,
+    ) {
+        // TODO: This code has gone through a rather traumatic series of y sign
+        //       flips and might benefit from refactoring for clarity?
+
+        let line_y = self.font.v_metrics(scale(font_size)).ascent;
+
+        // RustType requires a "draw pixel" callback that will be called for
+        // each pixel in the glyph's bounding box, in left-to-right
+        // top-to-bottom order. This is unfortunately incompatible with
+        // touchHLE's code which needs to be able to sample the pixels in any
+        // order in order to support rotation. This is worked around by creating
+        // a temporary bitmap for the glyph, and then the caller of this
+        // function can provide a "draw glyph" callback that can do whatever it
+        // wants with this bitmap.
+        // TODO: Do we need to increase the font size when scale transforms are
+        //       used, to avoid blurry text?
+        let mut glyph_bitmap: Vec<f32> = Vec::new();
+        let mut cumulative_x = 0.0;
+
+        for &glyph in glyphs {
+            let positioned_glyph = self.font
+                .glyph(glyph)
+                .scaled(scale(font_size))
+                .positioned(Point {
+                    x: origin.0 + cumulative_x,
+                    y: 0.0,
+                });
+            let Some(glyph_bounds) = positioned_glyph.pixel_bounding_box() else {
+                continue;
+            };
+            // y needs to be flipped to point up
+            let glyph_height = glyph_bounds.height();
+            let x_offset = glyph_bounds.min.x;
+            let y_offset = ((origin.1 + line_y).round() as i32) + glyph_bounds.max.y;
+
+            // TODO: Refactor this method to support y clipping too.
+            // It's not mandatory since the caller can do it, but it would
+            // be more efficient.
+            if let Some((wrap_width, _)) = wrap {
+                if glyph_bounds.min.x as f32 > origin.0 + wrap_width {
+                    // Avoid wasting effort on glyphs that are entirely
+                    // clipped. Partial clipping is the responsibility of
+                    // the draw_glyph implementation.
+                    continue;
+                }
+            }
+
+            let glyph_bitmap_bounds = (
+                glyph_bounds.width() as usize,
+                glyph_bounds.height() as usize,
+            );
+            glyph_bitmap.clear();
+            glyph_bitmap.resize(glyph_bitmap_bounds.0 * glyph_bitmap_bounds.1, 0.0);
+
+            positioned_glyph.draw(|x, y, coverage| {
+                glyph_bitmap[y as usize * glyph_bitmap_bounds.0 + x as usize] = coverage;
+            });
+
+            let raster_glyph = RasterGlyph {
+                origin: (x_offset as f32, y_offset as f32 - glyph_height as f32),
+                dimensions: (glyph_bitmap_bounds.0 as _, glyph_bitmap_bounds.1 as _),
+                pixels: &glyph_bitmap,
+            };
+
+            draw_glyph(raster_glyph);
+            cumulative_x += glyph_bounds.width() as f32;
         }
     }
 }

--- a/src/frameworks/audio_toolbox/audio_file.rs
+++ b/src/frameworks/audio_toolbox/audio_file.rs
@@ -219,6 +219,49 @@ pub fn AudioFileOpenWithCallbacks(
     0 // success
 }
 
+pub fn _AudioFileOpenFromVec(
+    env: &mut Environment,
+    data_vec: Vec<u8>,
+    in_file_type_hint: AudioFileTypeID,
+    out_audio_file: MutPtr<AudioFileID>,
+) -> OSStatus {
+    // The hint is optional and is supposed to only be used for certain file
+    // formats that can't be uniquely identified, which we don't support so far.
+    if in_file_type_hint != 0 {
+        log!("Ignoring file type hint for AudioFileOpenWithCallbacks()");
+    }
+
+    // TODO: We're just reading in the whole file at once and parsing it here,
+    // this should change when streaming parsing is implemented.
+    let size: u32 = data_vec.len() as u32;
+
+    assert!(
+        size != 0,
+        "0 byte size of file for AudioFileOpenWithCallbacks(), likely bad!"
+    );
+
+    let Ok(audio_file) = audio::AudioFile::read_from_vec(data_vec) else {
+        log!("Warning: AudioFileOpenWithCallbacks() failed parse",);
+        return kAudioFileUnsupportedFileTypeError;
+    };
+    let guest_audio_file = env.mem.alloc_and_write(OpaqueAudioFileID { _filler: 0 });
+
+    let host_object = AudioFileHostObject { audio_file };
+
+    State::get(&mut env.framework_state)
+        .audio_files
+        .insert(guest_audio_file, host_object);
+
+    env.mem.write(out_audio_file, guest_audio_file);
+
+    log_dbg!(
+        "AudioFileOpenWithCallbacks() opened, new audio file handle: {:?}",
+        guest_audio_file
+    );
+
+    0 // success
+}
+
 fn property_size(property_id: AudioFilePropertyID) -> GuestUSize {
     match property_id {
         kAudioFilePropertyDataFormat => guest_size_of::<AudioStreamBasicDescription>(),

--- a/src/frameworks/avfoundation/av_audio_player.rs
+++ b/src/frameworks/avfoundation/av_audio_player.rs
@@ -8,11 +8,7 @@
 //! Implemented using Audio Queue Services based on [the PlayingAudio example](https://developer.apple.com/library/archive/documentation/MusicAudio/Conceptual/AudioQueueProgrammingGuide/AQPlayback/PlayingAudio.html)
 
 use crate::dyld::HostFunction;
-use crate::frameworks::audio_toolbox::audio_file::{
-    self, kAudioFilePropertyDataFormat, kAudioFilePropertyPacketSizeUpperBound,
-    kAudioFileReadPermission, AudioFileClose, AudioFileGetProperty, AudioFileID, AudioFileOpenURL,
-    AudioFileReadPackets,
-};
+use crate::frameworks::audio_toolbox::audio_file::{self, kAudioFilePropertyDataFormat, kAudioFilePropertyPacketSizeUpperBound, kAudioFileReadPermission, AudioFileClose, AudioFileGetProperty, AudioFileID, AudioFileOpenURL, AudioFileReadPackets, _AudioFileOpenFromVec};
 use crate::frameworks::audio_toolbox::audio_queue::{
     kAudioQueueParam_Volume, AudioQueueAllocateBuffer, AudioQueueBufferRef, AudioQueueDispose,
     AudioQueueEnqueueBuffer, AudioQueueGetParameter, AudioQueueNewOutput, AudioQueueOutputCallback,
@@ -29,6 +25,7 @@ use crate::objc::{
 };
 use crate::objc_classes;
 use crate::Environment;
+use crate::frameworks::foundation::ns_data::to_rust_slice;
 
 const kNumberBuffers: usize = 3;
 
@@ -78,6 +75,30 @@ pub const CLASSES: ClassExports = objc_classes! {
         num_of_loops: 0
     });
     env.objc.alloc_object(this, host_object, &mut env.mem)
+}
+
+- (id)initWithData:(id)data // NSData*
+             error:(MutPtr<id>)outError { // NSError**
+    log!("Calling initWithData({:?})", data);
+    let bytes = to_rust_slice(env, data).to_vec();
+
+    // Check for errors. Return nil and write them to error if there are
+    let tmp_afi_ptr: MutPtr<AudioFileID> = env.mem.alloc(guest_size_of::<AudioFileID>()).cast();
+    let status = _AudioFileOpenFromVec(env, bytes, 0, tmp_afi_ptr);
+    let audio_file_id = env.mem.read(tmp_afi_ptr);
+    env.objc.borrow_mut::<AVAudioPlayerHostObject>(this).audio_file_id = Some(audio_file_id);
+    env.mem.free(tmp_afi_ptr.cast());
+    if status != 0 {
+        if !outError.is_null() {
+            let domain = ns_string::get_static_str(env, NSOSStatusErrorDomain);
+            let error = msg_class![env; NSError alloc];
+            let error = msg![env; error initWithDomain:domain code:status userInfo:nil];
+            env.mem.write(outError, error);
+        }
+        return nil;
+    }
+
+    this
 }
 
 - (id)initWithContentsOfURL:(id)url // NSURL*

--- a/src/frameworks/core_animation.rs
+++ b/src/frameworks/core_animation.rs
@@ -13,6 +13,7 @@ pub mod ca_eagl_layer;
 pub mod ca_layer;
 pub mod ca_media_timing_function;
 pub mod ca_transaction;
+pub mod ca_transform;
 
 mod animation;
 mod composition;
@@ -42,8 +43,12 @@ pub const DYLIB: crate::dyld::HostDylib = crate::dyld::HostDylib {
         ca_layer::CONSTANTS,
         ca_media_timing_function::CONSTANTS,
         ca_transaction::CONSTANTS,
+        ca_transform::CONSTANTS,
     ],
-    function_exports: &[FUNCTIONS],
+    function_exports: &[
+        FUNCTIONS,
+        ca_transform::FUNCTIONS,
+    ],
 };
 
 #[derive(Default)]

--- a/src/frameworks/core_animation/animation.rs
+++ b/src/frameworks/core_animation/animation.rs
@@ -18,17 +18,16 @@
 //!   <https://developer.apple.com/documentation/quartzcore/cabasicanimation?language=objc>
 use std::ops::Sub;
 
-use crate::frameworks::core_animation::ca_animation::{
-    get_animation_start_time, kCAFillModeBackwards, kCAFillModeBoth, kCAFillModeForwards,
-    CAMediaTimingFillMode,
-};
+use crate::frameworks::core_animation::ca_animation::{get_animation_start_time, kCAFillModeBackwards, kCAFillModeBoth, kCAFillModeForwards, CAMediaTimingFillMode};
 use crate::frameworks::core_animation::ca_layer::remove_anonymous_animation;
-use crate::frameworks::core_animation::{ca_layer::CALayerHostObject, CACurrentMediaTime};
+use crate::frameworks::core_animation::{ca_layer::CALayerHostObject, ca_transform, CACurrentMediaTime};
 use crate::frameworks::core_foundation::time::CFTimeInterval;
 use crate::frameworks::core_graphics::cg_color::CGColorHostObject;
 use crate::frameworks::foundation::ns_string::{from_rust_string, to_rust_string};
-use crate::objc::{id, msg, nil, release, retain};
+use crate::objc::{id, msg, nil, release, retain, ObjC};
 use crate::Environment;
+use crate::frameworks::core_graphics::cg_affine_transform::{CGAffineTransform};
+use crate::frameworks::foundation::{ns_array};
 
 #[derive(Default)]
 pub struct State {
@@ -142,114 +141,190 @@ impl State {
 
             // Assuming all animations here are CABasicAnimation
             // TODO: Handle other types of animations
-
-            let from_value: id = msg![env; animation fromValue];
-            let to_value: id = msg![env; animation toValue];
-            let by_value: id = msg![env; animation byValue];
-
             // Update values only in the presentation layer
             let key_path: id = msg![env; animation keyPath];
             let key_path = to_rust_string(env, key_path);
-            // Only these properties are animatable
-            // TODO: Implement for all properties
-            match &*key_path {
-                "anchorPoint" => {
-                    let from_value =
-                        id_as_option(from_value).map(|obj| msg![env; obj CGPointValue]);
-                    let to_value = id_as_option(to_value).map(|obj| msg![env; obj CGPointValue]);
-                    let by_value = id_as_option(by_value).map(|obj| msg![env; obj CGPointValue]);
-                    let (from_value, by_value) = get_from_and_by_values(
-                        Some(presentation.anchor_point),
-                        from_value,
-                        to_value,
-                        by_value,
-                    );
-                    presentation.anchor_point = from_value + by_value * interpolation_amount;
+            let key_path: Vec<&str> = key_path.split(".").collect();
+
+            let isa = ObjC::read_isa(animation, &env.mem);
+            let animation_class_name = env.objc.get_class_name(isa);
+            if animation_class_name == "CABasicAnimation" {
+                let from_value: id = msg![env; animation fromValue];
+                let to_value: id = msg![env; animation toValue];
+                let by_value: id = msg![env; animation byValue];
+
+                // Only these properties are animatable
+                // TODO: Implement for all properties
+                match &*key_path {
+                    ["anchorPoint"] => {
+                        let from_value =
+                            id_as_option(from_value).map(|obj| msg![env; obj CGPointValue]);
+                        let to_value = id_as_option(to_value).map(|obj| msg![env; obj CGPointValue]);
+                        let by_value = id_as_option(by_value).map(|obj| msg![env; obj CGPointValue]);
+                        let (from_value, by_value) = get_from_and_by_values(
+                            Some(presentation.anchor_point),
+                            from_value,
+                            to_value,
+                            by_value,
+                        );
+                        presentation.anchor_point = from_value + by_value * interpolation_amount;
+                    }
+                    ["backgroundColor"] => {
+                        let from_value = id_as_option(from_value)
+                            .map(|obj| *env.objc.borrow::<CGColorHostObject>(obj));
+                        let to_value = id_as_option(to_value)
+                            .map(|obj| *env.objc.borrow::<CGColorHostObject>(obj));
+                        let by_value = id_as_option(by_value)
+                            .map(|obj| *env.objc.borrow::<CGColorHostObject>(obj));
+                        let (from_value, by_value) = get_from_and_by_values(
+                            presentation.background_color,
+                            from_value,
+                            to_value,
+                            by_value,
+                        );
+                        presentation.background_color =
+                            Some(from_value + by_value * interpolation_amount)
+                    }
+                    ["bounds"] => {
+                        let from_value = id_as_option(from_value).map(|obj| msg![env; obj CGRectValue]);
+                        let to_value = id_as_option(to_value).map(|obj| msg![env; obj CGRectValue]);
+                        let by_value = id_as_option(by_value).map(|obj| msg![env; obj CGRectValue]);
+                        let (from_value, by_value) = get_from_and_by_values(
+                            Some(presentation.bounds),
+                            from_value,
+                            to_value,
+                            by_value,
+                        );
+                        presentation.bounds = from_value + by_value * interpolation_amount;
+                    }
+                    ["cornerRadius"] => {
+                        let from_value = id_as_option(from_value).map(|obj| msg![env; obj floatValue]);
+                        let to_value = id_as_option(to_value).map(|obj| msg![env; obj floatValue]);
+                        let by_value = id_as_option(by_value).map(|obj| msg![env; obj floatValue]);
+                        let (from_value, by_value) = get_from_and_by_values(
+                            Some(presentation.corner_radius),
+                            from_value,
+                            to_value,
+                            by_value,
+                        );
+                        presentation.corner_radius = from_value + by_value * interpolation_amount;
+                    }
+                    ["hidden"] => {
+                        let from_value = id_as_option(from_value)
+                            .map(|obj| msg![env; obj boolValue])
+                            .map(|val: bool| val as i32 as f32);
+                        let to_value = id_as_option(to_value)
+                            .map(|obj| msg![env; obj boolValue])
+                            .map(|val: bool| val as i32 as f32);
+                        let by_value = id_as_option(by_value)
+                            .map(|obj| msg![env; obj boolValue])
+                            .map(|val: bool| val as i32 as f32);
+                        let (from_value, by_value) = get_from_and_by_values(
+                            Some(presentation.hidden as i32 as f32),
+                            from_value,
+                            to_value,
+                            by_value,
+                        );
+                        presentation.hidden = (from_value + by_value * interpolation_amount) > 0.5;
+                    }
+                    ["opacity"] => {
+                        let from_value = id_as_option(from_value).map(|obj| msg![env; obj floatValue]);
+                        let to_value = id_as_option(to_value).map(|obj| msg![env; obj floatValue]);
+                        let by_value = id_as_option(by_value).map(|obj| msg![env; obj floatValue]);
+                        let (from_value, by_value) = get_from_and_by_values(
+                            Some(presentation.opacity),
+                            from_value,
+                            to_value,
+                            by_value,
+                        );
+                        presentation.opacity = from_value + by_value * interpolation_amount;
+                    }
+                    ["position"] => {
+                        let from_value =
+                            id_as_option(from_value).map(|obj| msg![env; obj CGPointValue]);
+                        let to_value = id_as_option(to_value).map(|obj| msg![env; obj CGPointValue]);
+                        let by_value = id_as_option(by_value).map(|obj| msg![env; obj CGPointValue]);
+                        let (from_value, by_value) = get_from_and_by_values(
+                            Some(presentation.position),
+                            from_value,
+                            to_value,
+                            by_value,
+                        );
+                        presentation.position = from_value + by_value * interpolation_amount;
+                    }
+                    _ => panic!("Attempted to animate on key {:?}", key_path),
                 }
-                "backgroundColor" => {
-                    let from_value = id_as_option(from_value)
-                        .map(|obj| *env.objc.borrow::<CGColorHostObject>(obj));
-                    let to_value = id_as_option(to_value)
-                        .map(|obj| *env.objc.borrow::<CGColorHostObject>(obj));
-                    let by_value = id_as_option(by_value)
-                        .map(|obj| *env.objc.borrow::<CGColorHostObject>(obj));
-                    let (from_value, by_value) = get_from_and_by_values(
-                        presentation.background_color,
-                        from_value,
-                        to_value,
-                        by_value,
-                    );
-                    presentation.background_color =
-                        Some(from_value + by_value * interpolation_amount)
+            } else if animation_class_name == "CAKeyframeAnimation" {
+                log!("CAKeyframeAnimation");
+                log!("KeyPath: {key_path:?}");
+                let key_times: id = msg![env; animation keyTimes];
+                let key_times: Vec<f32> = ns_array::to_vec(env, key_times).iter().map(|&id| -> f32 { msg![env; id floatValue] }).collect();
+                let (point_a_index, point_a) = key_times
+                    .clone()
+                    .into_iter()
+                    .enumerate()
+                    .filter(|&(_i,time)| time <= interpolation_amount)
+                    .max_by_key(|&(i, _time)| i)
+                    .unwrap();
+                let (point_b_index, point_b) = key_times
+                    .clone()
+                    .into_iter()
+                    .enumerate()
+                    .filter(|&(_i, time)| time >= interpolation_amount)
+                    .min_by_key(|&(i, _time)| i)
+                    .unwrap();
+                let interpolation_amount = (interpolation_amount - point_a) / (point_b - point_a);
+                match &*key_path {
+                    ["transform", "scale"] => {
+                        let values: id = msg![env; animation values];
+                        let values: Vec<f32> = ns_array::to_vec(env, values).iter().map(|&id| -> f32 { msg![env; id floatValue] }).collect();
+                        let interp_value = if point_a_index != point_b_index {
+                            let from_value = values[point_a_index];
+                            let to_value = values[point_b_index];
+                            let (from_value, by_value) = get_from_and_by_values(None, Some(from_value), Some(to_value), None);
+                            from_value + by_value * interpolation_amount
+                        } else {
+                            values[point_b_index]
+                        };
+                        log!("New scale value: {interp_value}");
+                        ca_transform::set_scale(&mut presentation.transform, interp_value, interp_value, 1f32);
+                        presentation.affine_transform = CGAffineTransform::make_scale(interp_value, interp_value).translate(presentation.affine_transform.tx,presentation.affine_transform.ty);
+                    }
+                    ["transform", "translation", translation_axis] => {
+                        let values: id = msg![env; animation values];
+                        let values: Vec<f32> = ns_array::to_vec(env, values).iter().map(|&id| -> f32 { msg![env; id floatValue] }).collect();
+                        let interp_value = if point_a_index != point_b_index {
+                            let from_value = values[point_a_index];
+                            let to_value = values[point_b_index];
+                            let (from_value, by_value) = get_from_and_by_values(None, Some(from_value), Some(to_value), None);
+                            from_value + by_value * interpolation_amount
+                        } else {
+                            values[point_b_index]
+                        };
+
+                        let translation_matrix_index = match *translation_axis {
+                            "x" => ca_transform::x_translation_index,
+                            "y" => ca_transform::y_translation_index,
+                            "z" => ca_transform::z_translation_index,
+                            _ => panic!("Unknown path in transform.translation: {translation_axis}")
+                        };
+                        log!("New translation {translation_axis} value: {interp_value}");
+
+                        presentation.transform[translation_matrix_index] = interp_value;
+                        match *translation_axis {
+                            "x" => presentation.affine_transform.tx = interp_value,
+                            "y" => presentation.affine_transform.ty = interp_value,
+                            "z" => { log!("ignoring setting z translation"); }
+                            _ => panic!("Unknown path in transform.translation: {translation_axis}")
+                        }
+                    }
+                    _ => {
+                        panic!("Unknown key path: {key_path:?}");
+                    }
                 }
-                "bounds" => {
-                    let from_value = id_as_option(from_value).map(|obj| msg![env; obj CGRectValue]);
-                    let to_value = id_as_option(to_value).map(|obj| msg![env; obj CGRectValue]);
-                    let by_value = id_as_option(by_value).map(|obj| msg![env; obj CGRectValue]);
-                    let (from_value, by_value) = get_from_and_by_values(
-                        Some(presentation.bounds),
-                        from_value,
-                        to_value,
-                        by_value,
-                    );
-                    presentation.bounds = from_value + by_value * interpolation_amount;
-                }
-                "cornerRadius" => {
-                    let from_value = id_as_option(from_value).map(|obj| msg![env; obj floatValue]);
-                    let to_value = id_as_option(to_value).map(|obj| msg![env; obj floatValue]);
-                    let by_value = id_as_option(by_value).map(|obj| msg![env; obj floatValue]);
-                    let (from_value, by_value) = get_from_and_by_values(
-                        Some(presentation.corner_radius),
-                        from_value,
-                        to_value,
-                        by_value,
-                    );
-                    presentation.corner_radius = from_value + by_value * interpolation_amount;
-                }
-                "hidden" => {
-                    let from_value = id_as_option(from_value)
-                        .map(|obj| msg![env; obj boolValue])
-                        .map(|val: bool| val as i32 as f32);
-                    let to_value = id_as_option(to_value)
-                        .map(|obj| msg![env; obj boolValue])
-                        .map(|val: bool| val as i32 as f32);
-                    let by_value = id_as_option(by_value)
-                        .map(|obj| msg![env; obj boolValue])
-                        .map(|val: bool| val as i32 as f32);
-                    let (from_value, by_value) = get_from_and_by_values(
-                        Some(presentation.hidden as i32 as f32),
-                        from_value,
-                        to_value,
-                        by_value,
-                    );
-                    presentation.hidden = (from_value + by_value * interpolation_amount) > 0.5;
-                }
-                "opacity" => {
-                    let from_value = id_as_option(from_value).map(|obj| msg![env; obj floatValue]);
-                    let to_value = id_as_option(to_value).map(|obj| msg![env; obj floatValue]);
-                    let by_value = id_as_option(by_value).map(|obj| msg![env; obj floatValue]);
-                    let (from_value, by_value) = get_from_and_by_values(
-                        Some(presentation.opacity),
-                        from_value,
-                        to_value,
-                        by_value,
-                    );
-                    presentation.opacity = from_value + by_value * interpolation_amount;
-                }
-                "position" => {
-                    let from_value =
-                        id_as_option(from_value).map(|obj| msg![env; obj CGPointValue]);
-                    let to_value = id_as_option(to_value).map(|obj| msg![env; obj CGPointValue]);
-                    let by_value = id_as_option(by_value).map(|obj| msg![env; obj CGPointValue]);
-                    let (from_value, by_value) = get_from_and_by_values(
-                        Some(presentation.position),
-                        from_value,
-                        to_value,
-                        by_value,
-                    );
-                    presentation.position = from_value + by_value * interpolation_amount;
-                }
-                _ => panic!("Attempted to animate on key {}", key_path),
+            } else {
+                log!("-- Unimplemented animation class: {}", animation_class_name);
+                log!("Unimplemented animation property: {:?} @ {}", key_path, interpolation_amount);
             }
         }
 

--- a/src/frameworks/core_animation/animation.rs
+++ b/src/frameworks/core_animation/animation.rs
@@ -255,9 +255,21 @@ impl State {
                     _ => panic!("Attempted to animate on key {:?}", key_path),
                 }
             } else if animation_class_name == "CAKeyframeAnimation" {
-                log!("CAKeyframeAnimation");
-                log!("KeyPath: {key_path:?}");
                 let key_times: id = msg![env; animation keyTimes];
+                if key_times == nil {
+                    log!("CAKeyframeAnimation has NIL key_times!");
+                    return presentation;
+                }
+                let key_times_class = ObjC::read_isa(key_times, &env.mem);
+                if key_times_class == nil {
+                    log!("CAKeyframeAnimation has key_times with NIL class?");
+                    return presentation;
+                }
+                let key_times_class_name = env.objc.get_class_name(key_times_class);
+                if !["NSArray", "NSMutableArray"].iter().any(|cn| key_times_class_name.ends_with(cn)) {
+                    log!("CAKeyframeAnimation has mismatched class {key_times_class_name} where NSArray is expected, memory corruption?");
+                    return presentation;
+                }
                 let key_times: Vec<f32> = ns_array::to_vec(env, key_times).iter().map(|&id| -> f32 { msg![env; id floatValue] }).collect();
                 let (point_a_index, point_a) = key_times
                     .clone()
@@ -286,7 +298,6 @@ impl State {
                         } else {
                             values[point_b_index]
                         };
-                        log!("New scale value: {interp_value}");
                         ca_transform::set_scale(&mut presentation.transform, interp_value, interp_value, 1f32);
                         presentation.affine_transform = CGAffineTransform::make_scale(interp_value, interp_value).translate(presentation.affine_transform.tx,presentation.affine_transform.ty);
                     }
@@ -308,7 +319,6 @@ impl State {
                             "z" => ca_transform::z_translation_index,
                             _ => panic!("Unknown path in transform.translation: {translation_axis}")
                         };
-                        log!("New translation {translation_axis} value: {interp_value}");
 
                         presentation.transform[translation_matrix_index] = interp_value;
                         match *translation_axis {

--- a/src/frameworks/core_animation/ca_animation.rs
+++ b/src/frameworks/core_animation/ca_animation.rs
@@ -12,7 +12,7 @@ use crate::frameworks::foundation::ns_string::{get_static_str, to_rust_string};
 use crate::objc::{
     autorelease, id, msg, nil, objc_classes, release, retain, ClassExports, HostObject, NSZonePtr,
 };
-use crate::Environment;
+use crate::{Environment};
 use crate::{impl_HostObject_with_superclass, msg_class, msg_super};
 
 type CATransitionType = id; // NSString*
@@ -20,6 +20,9 @@ const kCATransitionFade: &str = "fade";
 const kCATransitionMoveIn: &str = "moveIn";
 const kCATransitionPush: &str = "push";
 const kCATransitionReveal: &str = "reveal";
+
+pub type CAAnimationCalculationModeType = id; // NSString*
+pub const kCAAnimationLinear: &str = "kCAAnimationLinear";
 
 pub type CAMediaTimingFillMode = id; // NSString*
 pub const kCAFillModeBackwards: &str = "backwards";
@@ -44,6 +47,11 @@ pub const CONSTANTS: ConstantExports = &[
     (
         "_kCATransitionReveal",
         HostConstant::NSString(kCATransitionReveal),
+    ),
+    // `CAAnimationCalculationMode` values.
+    (
+        "_kCAAnimationLinear",
+        HostConstant::NSString(kCAAnimationLinear),
     ),
     // `CAMediaTimingFillMode` values.
     (
@@ -70,6 +78,7 @@ struct CAAnimationHostObject {
     begin_time: CFTimeInterval,
     duration: CFTimeInterval,
     fill_mode: &'static str,
+    calculation_mode: &'static str,
     started_at: Option<CFTimeInterval>,
 }
 impl HostObject for CAAnimationHostObject {}
@@ -85,6 +94,7 @@ impl Default for CAAnimationHostObject {
             duration: Default::default(),
             fill_mode: kCAFillModeRemoved,
             started_at: None,
+            calculation_mode: kCAAnimationLinear,
         }
     }
 }
@@ -102,8 +112,18 @@ struct CABasicAnimationHostObject {
     from_value: id,
     to_value: id,
     by_value: id,
+    animation_name: id,
 }
 impl_HostObject_with_superclass!(CABasicAnimationHostObject);
+
+#[derive(Default)]
+pub struct CAKeyframeAnimationHostObject {
+    superclass: CAPropertyAnimationHostObject,
+    duration: CFTimeInterval,
+    keyTimes: id, // NSArray<NSNumber>
+    values: id, // NSArray
+}
+impl_HostObject_with_superclass!(CAKeyframeAnimationHostObject);
 
 pub const CLASSES: ClassExports = objc_classes! {
 
@@ -205,6 +225,19 @@ pub const CLASSES: ClassExports = objc_classes! {
     get_static_str(env, fill_mode)
 }
 
+- (())setCalculationMode:(CAAnimationCalculationModeType)mode {
+    let calculation_mode_str = to_rust_string(env, mode);
+    let calculation_mode_str = match &*calculation_mode_str {
+        kCAAnimationLinear => kCAAnimationLinear,
+        _ => panic!("Unknown calculation mode \"{}\"", calculation_mode_str)
+    };
+    env.objc.borrow_mut::<CAAnimationHostObject>(this).calculation_mode = calculation_mode_str;
+}
+- (CAAnimationCalculationModeType)calculationMode {
+    let calculation_mode = env.objc.borrow::<CAAnimationHostObject>(this).calculation_mode;
+    get_static_str(env, calculation_mode)
+}
+
 - (())dealloc {
     let &CAAnimationHostObject { delegate, timing_function, .. } = env.objc.borrow(this);
     if delegate != nil {
@@ -289,6 +322,35 @@ pub const CLASSES: ClassExports = objc_classes! {
     env.objc.borrow::<CABasicAnimationHostObject>(this).by_value
 }
 
+// Cause of Death expects to be able to write to "animation-name"
+// Currently we have no way to either declare an ivar
+// or declare a setter with a non-identifier name
+- (())setValue:(id)value
+       forKey:(id)key { // NSString*
+    let key_string = to_rust_string(env, key); // TODO: avoid copy?
+    if key_string == "animation-name" {
+        let value_string = to_rust_string(env, value);
+        log!("setting \"animation-name\" to \"{}\" on CABasicAnimation({:?})!", value_string, this);
+        env.objc.borrow_mut::<CABasicAnimationHostObject>(this).animation_name = value;
+        return;
+    }
+    msg_super![env; this setValue:value forKey:key]
+}
+
+- (id) valueForKey:(id)key {
+    let key_string = to_rust_string(env, key); // TODO: avoid copy?
+    if key_string == "animation-name" {
+        return env.objc.borrow::<CABasicAnimationHostObject>(this).animation_name;
+    }
+    msg_super![env; this valueForKey:key]
+}
+
+- (()) setBeginTime: (f32) beginTime {
+    log!("Ignoring setBeginTime: {}", beginTime);
+    // Apple docs does not mention beginTime in any
+    // class of CABasicAnimation but Cause of Death calls it?
+}
+
 - (())dealloc {
     let &CABasicAnimationHostObject { from_value, to_value, .. } = env.objc.borrow(this);
     if from_value != nil {
@@ -301,6 +363,37 @@ pub const CLASSES: ClassExports = objc_classes! {
     msg_super![env; this dealloc]
 }
 
+@end
+
+
+@implementation CAKeyframeAnimation : CAPropertyAnimation
++ (id)allocWithZone:(NSZonePtr)_zone {
+    let host_object = Box::<CAKeyframeAnimationHostObject>::default();
+    env.objc.alloc_object(this, host_object, &mut env.mem)
+}
+
+- (CFTimeInterval) duration {
+    env.objc.borrow::<CAKeyframeAnimationHostObject>(this).duration
+}
+- (()) setDuration:(CFTimeInterval)duration {
+    env.objc.borrow_mut::<CAKeyframeAnimationHostObject>(this).duration = duration
+}
+
+- (())setValues:(id)values {
+    env.objc.borrow_mut::<CAKeyframeAnimationHostObject>(this).values = values;
+}
+
+- (())setKeyTimes:(id)keyTimes { // NSArray<NSNumber*>*
+    env.objc.borrow_mut::<CAKeyframeAnimationHostObject>(this).keyTimes = keyTimes;
+}
+
+- (id)values { // NSArray
+    env.objc.borrow_mut::<CAKeyframeAnimationHostObject>(this).values
+}
+
+- (id)keyTimes { // NSArray<NSNumber*>*
+    env.objc.borrow_mut::<CAKeyframeAnimationHostObject>(this).keyTimes
+}
 @end
 
 

--- a/src/frameworks/core_animation/ca_layer.rs
+++ b/src/frameworks/core_animation/ca_layer.rs
@@ -242,6 +242,9 @@ pub const CLASSES: ClassExports = objc_classes! {
 - (())setBounds:(CGRect)bounds {
     env.objc.borrow_mut::<CALayerHostObject>(this).bounds = bounds;
 }
+- (())setMasksToBounds:(bool)masksToBounds {
+    log!("Ignoring [(CALayer*){:?} setMasksToBounds:{:?}]", this, masksToBounds);
+}
 - (CGPoint)position {
     env.objc.borrow::<CALayerHostObject>(this).position
 }

--- a/src/frameworks/core_animation/ca_layer.rs
+++ b/src/frameworks/core_animation/ca_layer.rs
@@ -30,6 +30,7 @@ use crate::objc::{
 };
 use crate::Environment;
 use std::collections::{HashMap, HashSet};
+use crate::frameworks::core_animation::ca_transform::CATransform3D;
 
 #[derive(Clone)]
 pub(super) struct CALayerHostObject {
@@ -41,6 +42,7 @@ pub(super) struct CALayerHostObject {
     superlayer: id,
     pub(super) bounds: CGRect,
     pub(super) position: CGPoint,
+    pub(super) zPosition: CGFloat,
     pub(super) anchor_point: CGPoint,
     pub(super) affine_transform: CGAffineTransform,
     pub(super) hidden: bool,
@@ -49,6 +51,7 @@ pub(super) struct CALayerHostObject {
     pub(super) background_color: Option<CGColorHostObject>,
     pub(super) corner_radius: CGFloat,
     pub(super) needs_display: bool,
+    pub(super) transform: CATransform3D,
     /// `CGImageRef*`
     pub(super) contents: id,
     /// For CAEAGLLayer only
@@ -118,6 +121,7 @@ pub const CLASSES: ClassExports = objc_classes! {
             size: CGSize { width: 0.0, height: 0.0 }
         },
         position: CGPoint { x: 0.0, y: 0.0 },
+        zPosition: 0.0,
         anchor_point: CGPoint { x: 0.5, y: 0.5 },
         affine_transform: CGAffineTransformIdentity,
         hidden: false,
@@ -126,6 +130,7 @@ pub const CLASSES: ClassExports = objc_classes! {
         background_color: None, // transparency
         corner_radius: 0.0,
         needs_display: false,
+        transform: CATransform3D::identity(),
         contents: nil,
         drawable_properties: nil,
         presented_pixels: None,
@@ -242,6 +247,12 @@ pub const CLASSES: ClassExports = objc_classes! {
 }
 - (())setPosition:(CGPoint)position {
     env.objc.borrow_mut::<CALayerHostObject>(this).position = position;
+}
+- (CGFloat)zPosition {
+    env.objc.borrow::<CALayerHostObject>(this).zPosition
+}
+- (())setZPosition:(CGFloat)zPosition {
+    env.objc.borrow_mut::<CALayerHostObject>(this).zPosition = zPosition;
 }
 - (CGPoint)anchorPoint {
     env.objc.borrow::<CALayerHostObject>(this).anchor_point
@@ -424,6 +435,15 @@ pub const CLASSES: ClassExports = objc_classes! {
     CGContextTranslateCTM(env, cg_context, origin.x, origin.y);
 }
 
+// CATransform3D
+- (CATransform3D)transform {
+    env.objc.borrow::<CALayerHostObject>(this).transform
+}
+
+- (())setTransform:(CATransform3D)new_transform {
+    env.objc.borrow_mut::<CALayerHostObject>(this).transform = new_transform;
+}
+
 // CGImageRef*
 - (id)contents {
     env.objc.borrow::<CALayerHostObject>(this).contents
@@ -530,6 +550,14 @@ pub const CLASSES: ClassExports = objc_classes! {
     if let Some(anim) = env.objc.borrow_mut::<CALayerHostObject>(this).animations.remove(&*key_string) {
         release(env, anim);
     };
+}
+
+- (()) removeAllAnimations {
+    let animations = env.objc.borrow::<CALayerHostObject>(this).animations.values().map(|anim| *anim).collect::<Vec<id>>();
+    env.objc.borrow_mut::<CALayerHostObject>(this).animations.clear();
+    for anim in animations {
+        release(env, anim);
+    }
 }
 
 // TODO: more

--- a/src/frameworks/core_animation/ca_transform.rs
+++ b/src/frameworks/core_animation/ca_transform.rs
@@ -1,0 +1,132 @@
+use crate::abi::GuestArg;
+use crate::dyld::{ConstantExports, FunctionExports, HostConstant};
+use crate::environment::Environment;
+use crate::frameworks::core_graphics::CGFloat;
+use crate::mem::SafeRead;
+use crate::objc::HostObject;
+use crate::{export_c_func, impl_GuestRet_for_large_struct};
+use std::ops::{Index, IndexMut};
+
+#[derive(Debug, Default, Copy, Clone)]
+pub struct CATransform3D {
+    pub m11: CGFloat,
+    pub m12: CGFloat,
+    pub m13: CGFloat,
+    pub m14: CGFloat,
+    pub m21: CGFloat,
+    pub m22: CGFloat,
+    pub m23: CGFloat,
+    pub m24: CGFloat,
+    pub m31: CGFloat,
+    pub m32: CGFloat,
+    pub m33: CGFloat,
+    pub m34: CGFloat,
+    pub m41: CGFloat,
+    pub m42: CGFloat,
+    pub m43: CGFloat,
+    pub m44: CGFloat,
+}
+
+impl Index<(usize, usize)> for CATransform3D {
+    type Output = CGFloat;
+
+    fn index(&self, index: (usize, usize)) -> &Self::Output {
+        match index {
+            (1, 1) => &self.m11,
+            (1, 2) => &self.m12,
+            (1, 3) => &self.m13,
+            (1, 4) => &self.m14,
+            (2, 1) => &self.m21,
+            (2, 2) => &self.m22,
+            (2, 3) => &self.m23,
+            (2, 4) => &self.m24,
+            (3, 1) => &self.m31,
+            (3, 2) => &self.m32,
+            (3, 3) => &self.m33,
+            (3, 4) => &self.m34,
+            (4, 1) => &self.m41,
+            (4, 2) => &self.m42,
+            (4, 3) => &self.m43,
+            (4, 4) => &self.m44,
+            _ => panic!("Invalid index")
+        }
+    }
+}
+impl IndexMut<(usize, usize)> for CATransform3D {
+    fn index_mut(&mut self, index: (usize, usize)) -> &mut Self::Output {
+        match index {
+            (1, 1) => &mut self.m11,
+            (1, 2) => &mut self.m12,
+            (1, 3) => &mut self.m13,
+            (1, 4) => &mut self.m14,
+            (2, 1) => &mut self.m21,
+            (2, 2) => &mut self.m22,
+            (2, 3) => &mut self.m23,
+            (2, 4) => &mut self.m24,
+            (3, 1) => &mut self.m31,
+            (3, 2) => &mut self.m32,
+            (3, 3) => &mut self.m33,
+            (3, 4) => &mut self.m34,
+            (4, 1) => &mut self.m41,
+            (4, 2) => &mut self.m42,
+            (4, 3) => &mut self.m43,
+            (4, 4) => &mut self.m44,
+            _ => panic!("Invalid index")
+        }
+    }
+}
+impl CATransform3D {
+    pub fn identity() -> Self {
+        let mut transform = CATransform3D::default();
+        transform[(1,1)] = 1.0;
+        transform[(2,2)] = 1.0;
+        transform[(3,3)] = 1.0;
+        transform[(4,4)] = 1.0;
+        transform
+    }
+}
+unsafe impl SafeRead for CATransform3D {}
+impl HostObject for CATransform3D {}
+impl_GuestRet_for_large_struct!(CATransform3D);
+impl GuestArg for CATransform3D {
+    // TODO figure out how to pass big structs
+    //      as arguments in the ARMv6 calling convention
+    const REG_COUNT: usize = 0;
+
+    fn from_regs(_regs: &[u32]) -> Self {
+        CATransform3D::identity()
+    }
+
+    fn to_regs(self, _regs: &mut [u32]) {
+    }
+}
+pub fn CATransform3DMakeScale(_env: &mut Environment, sx: CGFloat, sy: CGFloat, sz: CGFloat) -> CATransform3D {
+    let mut transform = CATransform3D::default();
+    set_scale(&mut transform, sx, sy, sz);
+    transform
+}
+
+pub fn set_scale(transform: &mut CATransform3D, sx: CGFloat, sy: CGFloat, sz: CGFloat) {
+    transform[(1,1)] = sx;
+    transform[(2,2)] = sy;
+    transform[(3,3)] = sz;
+    transform[(4,4)] = 1.0;
+}
+
+pub const x_translation_index: (usize, usize) = (1, 4);
+pub const y_translation_index: (usize, usize) = (2, 4);
+pub const z_translation_index: (usize, usize) = (3, 4);
+
+pub const FUNCTIONS: FunctionExports = &[
+    export_c_func!(CATransform3DMakeScale(_,_,_))
+];
+
+
+pub const CONSTANTS: ConstantExports = &[(
+    "_CATransform3DIdentity",
+    HostConstant::Custom(|env| {
+        env.mem.alloc_and_write(CATransform3D::identity())
+            .cast()
+            .cast_const()
+    }),
+)];

--- a/src/frameworks/core_animation/composition.rs
+++ b/src/frameworks/core_animation/composition.rs
@@ -227,6 +227,7 @@ pub fn recomposite_if_necessary(env: &mut Environment, force: bool) -> Option<In
             let mut image = Image::from_pixel_vec(
                 vec![255u8; dimension * dimension * 4],
                 (dimension as _, dimension as _),
+                4,
             );
             image.round_corners(dimension as _, /* four_corners: */ false, /* add_sheen: */ false);
 

--- a/src/frameworks/core_graphics.rs
+++ b/src/frameworks/core_graphics.rs
@@ -16,6 +16,7 @@ pub mod cg_context;
 pub mod cg_data_provider;
 pub mod cg_geometry;
 pub mod cg_image;
+mod cg_font;
 
 pub const DYLIB: crate::dyld::HostDylib = crate::dyld::HostDylib {
     path: "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
@@ -25,6 +26,7 @@ pub const DYLIB: crate::dyld::HostDylib = crate::dyld::HostDylib {
         cg_color::CLASSES,
         cg_color_space::CLASSES,
         cg_context::CLASSES,
+        cg_font::CLASSES,
         cg_image::CLASSES,
     ],
     constant_exports: &[
@@ -39,6 +41,7 @@ pub const DYLIB: crate::dyld::HostDylib = crate::dyld::HostDylib {
         cg_color_space::FUNCTIONS,
         cg_context::FUNCTIONS,
         cg_data_provider::FUNCTIONS,
+        cg_font::FUNCTIONS,
         cg_geometry::FUNCTIONS,
         cg_image::FUNCTIONS,
     ],

--- a/src/frameworks/core_graphics/cg_bitmap_context.rs
+++ b/src/frameworks/core_graphics/cg_bitmap_context.rs
@@ -9,7 +9,7 @@ use super::cg_affine_transform::{CGAffineTransform, CGAffineTransformIdentity};
 use super::cg_color_space::{
     kCGColorSpaceGenericGray, kCGColorSpaceGenericRGB, CGColorSpaceHostObject, CGColorSpaceRef,
 };
-use super::cg_context::{CGContextHostObject, CGContextRef, CGContextSubclass};
+use super::cg_context::{CGContextHostObject, CGContextRef, CGContextState, CGContextSubclass};
 use super::cg_image::{
     self, kCGBitmapAlphaInfoMask, kCGBitmapByteOrderMask, kCGImageAlphaFirst, kCGImageAlphaLast,
     kCGImageAlphaNone, kCGImageAlphaNoneSkipFirst, kCGImageAlphaNoneSkipLast, kCGImageAlphaOnly,
@@ -20,8 +20,9 @@ use super::{CGFloat, CGPoint, CGRect};
 use crate::dyld::{export_c_func, FunctionExports};
 use crate::image::{gamma_decode, gamma_encode, Image};
 use crate::mem::{GuestUSize, Mem, MutVoidPtr};
-use crate::objc::ObjC;
+use crate::objc::{nil, ObjC};
 use crate::Environment;
+use crate::frameworks::core_graphics::cg_geometry::CGSizeZero;
 
 #[derive(Copy, Clone)]
 pub(super) struct CGBitmapContextData {
@@ -81,9 +82,20 @@ pub fn CGBitmapContextCreate(
             alpha_info: bitmap_info & kCGBitmapAlphaInfoMask,
         }),
         // TODO: is this the correct default?
-        rgb_fill_color: (0.0, 0.0, 0.0, 0.0),
-        transform: CGAffineTransformIdentity,
+        state: CGContextState {
+            rgb_fill_color: (0.0, 0.0, 0.0, 0.0),
+            rgb_stroke_color: (0.0, 0.0, 0.0, 0.0),
+            transform: CGAffineTransformIdentity,
+            line_width: 1.0,
+            text_font: nil,
+            font_size: 1.0,
+            text_drawing_mode: 0,
+            shadow_blur: 0.0,
+            shadow_color: nil,
+            shadow_offset: CGSizeZero,
+        },
         state_stack: Vec::new(),
+        text_matrix: CGAffineTransformIdentity,
     };
     let isa = env
         .objc
@@ -139,7 +151,7 @@ pub fn CGBitmapContextCreateImage(env: &mut Environment, context: CGContextRef) 
         .to_vec();
     cg_image::from_image(
         env,
-        Image::from_pixel_vec(pixels, (bitmap_data.width, bitmap_data.height)),
+        Image::from_pixel_vec(pixels, (bitmap_data.width, bitmap_data.height), 4),
     )
 }
 
@@ -244,17 +256,7 @@ fn blend_premultiplied(bg: (f32, f32, f32, f32), fg: (f32, f32, f32, f32)) -> (f
 /// per component offsets (r, g, b, a)
 fn pixel_offsets(data: &CGBitmapContextData) -> (usize, usize, usize, Option<usize>) {
     match data.color_space {
-        kCGColorSpaceGenericRGB => {
-            match data.alpha_info {
-                kCGImageAlphaNone => (0, 1, 2, None),
-                kCGImageAlphaPremultipliedLast | kCGImageAlphaLast => (0, 1, 2, Some(3)),
-                kCGImageAlphaPremultipliedFirst | kCGImageAlphaFirst => (1, 2, 3, Some(0)),
-                kCGImageAlphaNoneSkipLast => (0, 1, 2, None),
-                kCGImageAlphaNoneSkipFirst => (1, 2, 3, None),
-                kCGImageAlphaOnly => (0, 0, 0, Some(0)),
-                _ => unreachable!(), // checked by bytes_per_pixel
-            }
-        }
+        kCGColorSpaceGenericRGB => pixel_offsets_rgb(data.alpha_info),
         kCGColorSpaceGenericGray => {
             // TODO: this is probably isn't doing RGB to grayscale conversion
             // properly
@@ -269,6 +271,18 @@ fn pixel_offsets(data: &CGBitmapContextData) -> (usize, usize, usize, Option<usi
             }
         }
         _ => unimplemented!(),
+    }
+}
+
+pub fn pixel_offsets_rgb(alpha_info: CGImageAlphaInfo) -> (usize, usize, usize, Option<usize>) {
+    match alpha_info {
+        kCGImageAlphaNone => (0, 1, 2, None),
+        kCGImageAlphaPremultipliedLast | kCGImageAlphaLast => (0, 1, 2, Some(3)),
+        kCGImageAlphaPremultipliedFirst | kCGImageAlphaFirst => (1, 2, 3, Some(0)),
+        kCGImageAlphaNoneSkipLast => (0, 1, 2, None),
+        kCGImageAlphaNoneSkipFirst => (1, 2, 3, None),
+        kCGImageAlphaOnly => (0, 0, 0, Some(0)),
+        _ => unreachable!(), // checked by bytes_per_pixel
     }
 }
 
@@ -372,9 +386,19 @@ impl CGBitmapContextDrawer<'_> {
     ) -> CGBitmapContextDrawer<'a> {
         let &CGContextHostObject {
             subclass: CGContextSubclass::CGBitmapContext(bitmap_info),
-            rgb_fill_color,
-            transform,
-            ..
+            state: CGContextState {
+                rgb_fill_color,
+                rgb_stroke_color: _,
+                transform,
+                line_width: _,
+                font_size: _,
+                text_font: _,
+                text_drawing_mode: _,
+                shadow_offset: _,
+                shadow_color: _,
+                shadow_blur: _,
+            },
+        ..
         } = objc.borrow(context);
 
         let pixels = get_pixels(&bitmap_info, mem);

--- a/src/frameworks/core_graphics/cg_context.rs
+++ b/src/frameworks/core_graphics/cg_context.rs
@@ -169,6 +169,14 @@ fn CGContextClipToRect(env: &mut Environment, context: CGContextRef, rect: CGRec
         // All good, clipping is not needed!
         return;
     }
+    if env
+        .bundle
+        .bundle_identifier()
+        .starts_with("com.ea.causeofdeath")
+    {
+        log_dbg!("Ignoring CGContextClipToRect for Cause of Death.");
+        return;
+    }
     todo!();
 }
 

--- a/src/frameworks/core_graphics/cg_context.rs
+++ b/src/frameworks/core_graphics/cg_context.rs
@@ -5,9 +5,10 @@
  */
 //! `CGContext.h`
 
+use owned_ttf_parser::GlyphId;
 use super::cg_affine_transform::CGAffineTransform;
 use super::cg_image::CGImageRef;
-use super::{cg_bitmap_context, CGFloat, CGRect};
+use super::{cg_bitmap_context, CGFloat, CGPoint, CGRect, CGSize};
 use crate::dyld::{export_c_func, FunctionExports};
 use crate::frameworks::core_foundation::{CFRelease, CFRetain, CFTypeRef};
 use crate::frameworks::core_graphics::cg_bitmap_context::{
@@ -16,8 +17,13 @@ use crate::frameworks::core_graphics::cg_bitmap_context::{
 use crate::frameworks::core_graphics::cg_geometry::CGPointZero;
 use crate::objc::{objc_classes, ClassExports, HostObject};
 use crate::Environment;
+use crate::frameworks::core_graphics::cg_color::CGColorRef;
+use crate::frameworks::core_graphics::cg_font::{glyphs_at_point, CGFontRef, CGGlyph};
+use crate::mem::{ConstPtr, GuestUSize};
 
 type CGInterpolationQuality = i32;
+pub type CGTextDrawingMode = i32;
+// TODO: find constant values for this enum
 
 pub const CLASSES: ClassExports = objc_classes! {
 
@@ -42,13 +48,29 @@ pub const CLASSES: ClassExports = objc_classes! {
 
 };
 
-pub(super) struct CGContextHostObject {
-    pub(super) subclass: CGContextSubclass,
+#[derive(Copy, Clone)]
+pub(super) struct CGContextState {
     pub(super) rgb_fill_color: (CGFloat, CGFloat, CGFloat, CGFloat),
+    pub(super) rgb_stroke_color: (CGFloat, CGFloat, CGFloat, CGFloat),
+    pub(super) line_width: CGFloat,
     /// Current transform.
     pub(super) transform: CGAffineTransform,
+    pub(super) font_size: CGFloat,
+    pub(super) text_font: CGFontRef,
+    pub(super) text_drawing_mode: CGTextDrawingMode,
+    pub(super) shadow_offset: CGSize,
+    pub(super) shadow_blur: CGFloat,
+    pub(super) shadow_color: CGColorRef,
+}
+
+pub(super) struct CGContextHostObject {
+    pub(super) subclass: CGContextSubclass,
+    pub(super) state: CGContextState,
     // TODO: keep more states saved once they are implemented
-    pub(super) state_stack: Vec<((CGFloat, CGFloat, CGFloat, CGFloat), CGAffineTransform)>,
+    pub(super) state_stack: Vec<CGContextState>,
+    // TODO: according to documentation these aren't part of state and 
+    //       aren't affected by pop/push, check if true?
+    pub(super) text_matrix: CGAffineTransform,
 }
 impl HostObject for CGContextHostObject {}
 
@@ -71,6 +93,32 @@ pub fn CGContextRetain(env: &mut Environment, c: CGContextRef) -> CGContextRef {
     }
 }
 
+pub fn CGContextSetLineWidth(
+    env: &mut Environment,
+    context: CGContextRef,
+    line_width: CGFloat,
+) {
+    env.objc
+        .borrow_mut::<CGContextHostObject>(context)
+        .state
+        .line_width = line_width;
+}
+
+pub fn CGContextSetRGBStrokeColor(
+    env: &mut Environment,
+    context: CGContextRef,
+    red: CGFloat,
+    green: CGFloat,
+    blue: CGFloat,
+    alpha: CGFloat,
+) {
+    let color = (red, green, blue, alpha);
+    env.objc
+        .borrow_mut::<CGContextHostObject>(context)
+        .state
+        .rgb_stroke_color = color;
+}
+
 pub fn CGContextSetRGBFillColor(
     env: &mut Environment,
     context: CGContextRef,
@@ -82,6 +130,7 @@ pub fn CGContextSetRGBFillColor(
     let color = (red, green, blue, alpha);
     env.objc
         .borrow_mut::<CGContextHostObject>(context)
+        .state
         .rgb_fill_color = color;
 }
 
@@ -94,6 +143,7 @@ fn CGContextSetGrayFillColor(
     let color = (gray, gray, gray, alpha);
     env.objc
         .borrow_mut::<CGContextHostObject>(context)
+        .state
         .rgb_fill_color = color;
 }
 
@@ -113,6 +163,7 @@ fn CGContextClipToRect(env: &mut Environment, context: CGContextRef, rect: CGRec
         assert!(env
             .objc
             .borrow_mut::<CGContextHostObject>(context)
+            .state
             .transform
             .is_identity());
         // All good, clipping is not needed!
@@ -128,22 +179,22 @@ pub fn CGContextConcatCTM(
 ) {
     log_dbg!("CGContextConcatCTM({:?})", transform);
     let host_obj = env.objc.borrow_mut::<CGContextHostObject>(context);
-    host_obj.transform = transform.concat(host_obj.transform);
+    host_obj.state.transform = transform.concat(host_obj.state.transform);
 }
 pub fn CGContextGetCTM(env: &mut Environment, context: CGContextRef) -> CGAffineTransform {
-    let res = env.objc.borrow::<CGContextHostObject>(context).transform;
+    let res = env.objc.borrow::<CGContextHostObject>(context).state.transform;
     log_dbg!("CGContextGetCTM() => {:?}", res);
     res
 }
 pub fn CGContextRotateCTM(env: &mut Environment, context: CGContextRef, angle: CGFloat) {
     log_dbg!("CGContextRotateCTM({:?})", angle);
     let host_obj = env.objc.borrow_mut::<CGContextHostObject>(context);
-    host_obj.transform = host_obj.transform.rotate(angle);
+    host_obj.state.transform = host_obj.state.transform.rotate(angle);
 }
 pub fn CGContextScaleCTM(env: &mut Environment, context: CGContextRef, x: CGFloat, y: CGFloat) {
     log_dbg!("CGContextScaleCTM({:?})", (x, y));
     let host_obj = env.objc.borrow_mut::<CGContextHostObject>(context);
-    host_obj.transform = host_obj.transform.scale(x, y);
+    host_obj.state.transform = host_obj.state.transform.scale(x, y);
 }
 pub fn CGContextTranslateCTM(
     env: &mut Environment,
@@ -153,7 +204,7 @@ pub fn CGContextTranslateCTM(
 ) {
     log_dbg!("CGContextTranslateCTM({:?})", (tx, ty));
     let host_obj = env.objc.borrow_mut::<CGContextHostObject>(context);
-    host_obj.transform = host_obj.transform.translate(tx, ty);
+    host_obj.state.transform = host_obj.state.transform.translate(tx, ty);
 }
 
 pub fn CGContextDrawImage(
@@ -169,14 +220,13 @@ fn CGContextSaveGState(env: &mut Environment, context: CGContextRef) {
     let host_obj = env.objc.borrow_mut::<CGContextHostObject>(context);
     host_obj
         .state_stack
-        .push((host_obj.rgb_fill_color, host_obj.transform));
+        .push(host_obj.state);
 }
 
 fn CGContextRestoreGState(env: &mut Environment, context: CGContextRef) {
     let host_obj = env.objc.borrow_mut::<CGContextHostObject>(context);
     let state = host_obj.state_stack.pop().unwrap();
-    host_obj.rgb_fill_color = state.0;
-    host_obj.transform = state.1;
+    host_obj.state = state;
 }
 
 fn CGContextSetInterpolationQuality(
@@ -191,10 +241,52 @@ fn CGContextSetInterpolationQuality(
     );
 }
 
+pub fn CGContextGetClipBoundingBox(
+    _env: &mut Environment,
+    _context: CGContextRef,
+) -> CGRect {
+    CGRect::default()
+}
+
+pub fn CGContextSetTextMatrix(env: &mut Environment, context: CGContextRef, matrix: CGAffineTransform) {
+    env.objc.borrow_mut::<CGContextHostObject>(context).text_matrix = matrix;
+}
+
+pub fn CGContextSetFont(env: &mut Environment, context: CGContextRef, font: CGFontRef) {
+    env.objc.borrow_mut::<CGContextHostObject>(context).state.text_font = font;
+}
+
+pub fn CGContextSetFontSize(env: &mut Environment, context: CGContextRef, font_size: CGFloat) {
+    env.objc.borrow_mut::<CGContextHostObject>(context).state.font_size = font_size;
+}
+
+pub fn CGContextSetTextDrawingMode(env: &mut Environment, context: CGContextRef, mode: CGTextDrawingMode) {
+    env.objc.borrow_mut::<CGContextHostObject>(context).state.text_drawing_mode = mode;
+}
+
+pub fn CGContextSetShadowWithColor(env: &mut Environment, context: CGContextRef, offset: CGSize, blur: CGFloat, color: CGColorRef) {
+    env.objc.borrow_mut::<CGContextHostObject>(context).state.shadow_offset = offset;
+    env.objc.borrow_mut::<CGContextHostObject>(context).state.shadow_blur = blur;
+    env.objc.borrow_mut::<CGContextHostObject>(context).state.shadow_color = color;
+}
+
+pub fn CGContextShowGlyphsAtPoint(env: &mut Environment, context: CGContextRef, x: CGFloat, y: CGFloat, glyphs: ConstPtr<CGGlyph>, count: GuestUSize) {
+    let context = env.objc.borrow::<CGContextHostObject>(context);
+    let glyphs = (0..count)
+        .map(|i| env.mem.read(glyphs+i))
+        .map(GlyphId)
+        .collect::<Vec<_>>();
+    glyphs_at_point(env, context.state.text_font, &glyphs, CGPoint {
+        x, y
+    })
+}
+
 pub const FUNCTIONS: FunctionExports = &[
     export_c_func!(CGContextRetain(_)),
     export_c_func!(CGContextRelease(_)),
+    export_c_func!(CGContextSetLineWidth(_, _)),
     export_c_func!(CGContextSetRGBFillColor(_, _, _, _, _)),
+    export_c_func!(CGContextSetRGBStrokeColor(_, _, _, _, _)),
     export_c_func!(CGContextSetGrayFillColor(_, _, _)),
     export_c_func!(CGContextFillRect(_, _)),
     export_c_func!(CGContextClearRect(_, _)),
@@ -208,4 +300,11 @@ pub const FUNCTIONS: FunctionExports = &[
     export_c_func!(CGContextSaveGState(_)),
     export_c_func!(CGContextRestoreGState(_)),
     export_c_func!(CGContextSetInterpolationQuality(_, _)),
+    export_c_func!(CGContextGetClipBoundingBox(_)),
+    export_c_func!(CGContextSetTextMatrix(_, _)),
+    export_c_func!(CGContextSetFont(_, _)),
+    export_c_func!(CGContextSetFontSize(_, _)),
+    export_c_func!(CGContextSetTextDrawingMode(_, _)),
+    export_c_func!(CGContextSetShadowWithColor(_, _, _, _)),
+    export_c_func!(CGContextShowGlyphsAtPoint(_, _, _, _, _)),
 ];

--- a/src/frameworks/core_graphics/cg_data_provider.rs
+++ b/src/frameworks/core_graphics/cg_data_provider.rs
@@ -17,7 +17,7 @@ use crate::frameworks::core_foundation::cf_url::CFURLRef;
 use crate::frameworks::core_foundation::{CFRelease, CFRetain, CFTypeRef};
 use crate::frameworks::foundation::ns_string::to_rust_string;
 use crate::frameworks::foundation::NSUInteger;
-use crate::mem::{ConstVoidPtr, GuestUSize, MutVoidPtr};
+use crate::mem::{ConstPtr, ConstVoidPtr, GuestUSize, MutVoidPtr};
 use crate::objc::{id, msg, msg_class, objc_classes, ClassExports, HostObject};
 use crate::Environment;
 
@@ -94,6 +94,21 @@ pub fn CGDataProviderRetain(env: &mut Environment, c: CGDataProviderRef) -> CGDa
     } else {
         c
     }
+}
+
+fn CGDataProviderCreateWithFilename(
+    env: &mut Environment,
+    filename: ConstPtr<u8>,
+) -> CGDataProviderRef {
+    let filename: id = msg_class![env; NSString stringWithCString:filename];
+    let ns_data: id = msg_class![env; NSData dataWithContentsOfFile:filename];
+    let bytes: ConstVoidPtr = msg![env; ns_data bytes];
+    let length: NSUInteger = msg![env; ns_data length];
+    let cf_data = CFDataCreate(env, kCFAllocatorDefault, bytes.cast(), length.cast_signed());
+    CGDataProviderCreateWithCFData(
+        env,
+        cf_data
+    )
 }
 
 fn CGDataProviderCreateWithData(
@@ -205,6 +220,7 @@ fn CGDataProviderCreateWithCFData(env: &mut Environment, data: CFDataRef) -> CGD
 pub const FUNCTIONS: FunctionExports = &[
     export_c_func!(CGDataProviderRetain(_)),
     export_c_func!(CGDataProviderRelease(_)),
+    export_c_func!(CGDataProviderCreateWithFilename(_)),
     export_c_func!(CGDataProviderCreateWithData(_, _, _, _)),
     export_c_func!(CGDataProviderCopyData(_)),
     export_c_func!(CGDataProviderCreateWithURL(_)),

--- a/src/frameworks/core_graphics/cg_font.rs
+++ b/src/frameworks/core_graphics/cg_font.rs
@@ -1,0 +1,173 @@
+use owned_ttf_parser::GlyphId;
+use crate::dyld::FunctionExports;
+use crate::environment::Environment;
+use crate::frameworks::core_foundation::cf_string::CFStringRef;
+use crate::frameworks::core_foundation::{CFIndex, CFTypeRef};
+use crate::objc::{id, ClassExports, HostObject};
+use crate::{export_c_func, objc_classes};
+use crate::font::{Font, TextAlignment};
+use crate::frameworks::core_foundation::cf_allocator::kCFAllocatorDefault;
+use crate::frameworks::core_foundation::cf_data::{CFDataCreate, CFDataRef};
+use crate::frameworks::core_graphics::cg_data_provider::CGDataProviderRef;
+use crate::frameworks::core_graphics::{CGPoint, CGRect, CGSize};
+use crate::frameworks::core_graphics::cg_bitmap_context::CGBitmapContextDrawer;
+use crate::frameworks::core_graphics::cg_context::CGContextHostObject;
+use crate::frameworks::foundation::ns_string::{from_rust_string, to_rust_string};
+use crate::frameworks::uikit::ui_graphics::UIGraphicsGetCurrentContext;
+use crate::mem::{ConstPtr, GuestUSize, MutPtr};
+
+pub type CGFontRef = CFTypeRef;
+pub struct CGFontHostObject {
+    font: Font,
+}
+impl HostObject for CGFontHostObject {}
+pub type CGFontIndex = u16;
+pub type CGGlyph = CGFontIndex;
+pub const CLASSES: ClassExports = objc_classes! {
+
+(env, this, _cmd);
+
+@implementation CGFont: NSObject
+@end
+
+};
+
+/// Called by 
+/// `crate::frameworks::core_graphics::cg_context::CGContextShowGlyphsAtPoint`
+pub fn glyphs_at_point(
+    env: &mut Environment,
+    font: id,
+    glyphs: &[GlyphId],
+    point: CGPoint,
+) {
+    let context = UIGraphicsGetCurrentContext(env);
+
+    let host_object = env.objc.borrow::<CGFontHostObject>(font);
+
+    let font = &host_object.font;
+    let context_host = env.objc.borrow::<CGContextHostObject>(context);
+
+    let mut drawer = CGBitmapContextDrawer::new(&env.objc, &mut env.mem, context);
+    let fill_color = drawer.rgb_fill_color();
+
+    font.draw_glyphs(
+        context_host.state.font_size * 0.5,
+        glyphs,
+        (point.x, point.y),
+        None,
+        TextAlignment::Left,
+        |raster_glyph| {
+            crate::frameworks::uikit::ui_font::draw_font_glyph(
+                &mut drawer,
+                raster_glyph,
+                fill_color,
+                /* clip_x: */ None,
+                /* clip_y: */ None,
+            )
+        },
+    );
+}
+
+pub fn CGFontCreateWithFontName(env: &mut Environment, name: CFStringRef) -> CGFontRef {
+    let host_obj = Box::new(CGFontHostObject {
+        font: Font::sans_regular() // TODO actually load requested font.
+    });
+    let name = to_rust_string(env, name);
+    log!("Ignoring CGFontCreateWithFontName((CFString*){:?})", name);
+    let class = env.objc.get_known_class("CGFont", &mut env.mem);
+    env.objc.alloc_object(class, host_obj, &mut env.mem)
+}
+
+pub fn CGFontCreateWithDataProvider(env: &mut Environment, provider: CGDataProviderRef) -> CGFontRef {
+    log!("Ignoring CGFontCreateWithDataProvider((CGDataProvider*){:?})", provider);
+    let host_obj = Box::new(CGFontHostObject {
+        font: Font::sans_regular() // TODO actually load requested font.
+    });
+    let class = env.objc.get_known_class("CGFont", &mut env.mem);
+    env.objc.alloc_object(class, host_obj, &mut env.mem)
+}
+
+pub fn CGFontCopyTableForTag(env: &mut Environment, font: CGFontRef, tag: u32) -> CFDataRef {
+    let font = env.objc.borrow::<CGFontHostObject>(font);
+    let table_bytes = font.font.get_raw_table(tag);
+    let table_bytes_guest = env.mem.alloc(table_bytes.len() as GuestUSize).cast();
+    for (i, &table_byte) in table_bytes.iter().enumerate() {
+        env.mem.write::<u8>(table_bytes_guest + i as GuestUSize, table_byte);
+    }
+    CFDataCreate(env, kCFAllocatorDefault, table_bytes_guest.cast_const(), table_bytes.len() as CFIndex)
+}
+
+pub fn CGFontCopyFullName(env: &mut Environment, font: CGFontRef) -> CFStringRef {
+    let font = env.objc.borrow::<CGFontHostObject>(font);
+    from_rust_string(env, font.font.name())
+}
+
+pub fn CGFontGetGlyphBBoxes(env: &mut Environment, font: CGFontRef, glyphs: ConstPtr<CGGlyph>, count: GuestUSize, bboxes: MutPtr<CGRect>) -> bool {
+    let font = env.objc.borrow::<CGFontHostObject>(font);
+    let mut point = CGPoint {
+        x: 0.0,
+        y: 0.0,
+    };
+
+    for (x, i) in (1..count)
+        .map(|i| (glyphs + i, i))
+        .map(|(ptr, i)| (env.mem.read(ptr), i))
+        .collect::<Vec<_>>() {
+        let bbox = font.font.glyph_size(GlyphId(x));
+        let width = bbox.width() as f32;
+        let height = bbox.height() as f32;
+        let rect = CGRect {
+            origin: point,
+            size: CGSize {
+                width,
+                height,
+            }
+        };
+        env.mem.write(bboxes + i, rect);
+        point.x += width;
+    }
+    true
+}
+
+pub fn CGFontGetGlyphAdvances(env: &mut Environment, font: CGFontRef, glyphs: ConstPtr<CGGlyph>, count: GuestUSize, advances: MutPtr<i32>) -> bool {
+    let font = env.objc.borrow::<CGFontHostObject>(font);
+    for (x, i) in (1..count)
+        .map(|i| (glyphs + i, i))
+        .map(|(ptr, i)| (env.mem.read(ptr), i))
+        .collect::<Vec<_>>() {
+        env.mem.write(advances + i, font.font.advance_unscaled(x));
+    }
+    true
+}
+
+pub fn CGFontGetAscent(env: &mut Environment, font: CGFontRef) -> i32 {
+    let font = env.objc.borrow::<CGFontHostObject>(font);
+    font.font.ascent_unscaled()
+}
+
+pub fn CGFontGetDescent(env: &mut Environment, font: CGFontRef) -> i32 {
+    let font = env.objc.borrow::<CGFontHostObject>(font);
+    font.font.descent_unscaled()
+}
+pub fn CGFontGetCapHeight(env: &mut Environment, font: CGFontRef) -> i32 {
+    let font = env.objc.borrow::<CGFontHostObject>(font);
+    font.font.cap_height()
+}
+
+pub fn CGFontGetUnitsPerEm(env: &mut Environment, font: CGFontRef) -> i32 {
+    let font = env.objc.borrow::<CGFontHostObject>(font);
+    font.font.units_per_em() as i32
+}
+
+pub const FUNCTIONS: FunctionExports = &[
+    export_c_func!(CGFontCopyFullName(_)),
+    export_c_func!(CGFontCreateWithFontName(_)),
+    export_c_func!(CGFontCreateWithDataProvider(_)),
+    export_c_func!(CGFontCopyTableForTag(_, _)),
+    export_c_func!(CGFontGetGlyphBBoxes(_, _, _, _)),
+    export_c_func!(CGFontGetGlyphAdvances(_, _, _, _)),
+    export_c_func!(CGFontGetAscent(_)),
+    export_c_func!(CGFontGetDescent(_)),
+    export_c_func!(CGFontGetUnitsPerEm(_)),
+    export_c_func!(CGFontGetCapHeight(_)),
+];

--- a/src/frameworks/core_graphics/cg_image.rs
+++ b/src/frameworks/core_graphics/cg_image.rs
@@ -5,9 +5,7 @@
  */
 //! `CGImage.h`
 
-use super::cg_color_space::{
-    kCGColorSpaceGenericRGB, CGColorSpaceCreateWithName, CGColorSpaceGetModel, CGColorSpaceRef,
-};
+use super::cg_color_space::{kCGColorSpaceGenericRGB, CGColorSpaceCreateWithName, CGColorSpaceGetModel, CGColorSpaceRef};
 use super::cg_data_provider::{self, CGDataProviderRef};
 use super::CGFloat;
 use crate::dyld::{export_c_func, FunctionExports};
@@ -17,6 +15,7 @@ use crate::image::Image;
 use crate::mem::{ConstPtr, GuestUSize};
 use crate::objc::{autorelease, nil, objc_classes, ClassExports, HostObject, ObjC};
 use crate::Environment;
+use crate::frameworks::core_graphics::cg_bitmap_context::{pixel_offsets_rgb};
 
 pub type CGImageAlphaInfo = u32;
 pub const kCGImageAlphaNone: CGImageAlphaInfo = 0;
@@ -43,6 +42,9 @@ pub type CGBitmapInfo = u32;
 pub const kCGBitmapAlphaInfoMask: CGBitmapInfo = 0x1F; // huh, it's not 0x7?
 pub const kCGBitmapByteOrderMask: CGBitmapInfo = kCGImageByteOrderMask;
 // TODO: other stuff in this enum (for now, always assert the rest is 0)
+
+pub type CGColorRenderingIntent = i32;
+// TODO figure out values for this enum
 
 pub const CLASSES: ClassExports = objc_classes! {
 
@@ -97,6 +99,63 @@ pub fn borrow_image_mut(objc: &mut ObjC, image: CGImageRef) -> &mut Image {
 
 // TODO: More create methods.
 
+fn CGImageCreate(
+    env: &mut Environment,
+    width: GuestUSize,
+    height: GuestUSize,
+    _bits_per_component: GuestUSize,
+    bits_per_pixel: GuestUSize,
+    _bytes_per_row: GuestUSize,
+    _color_space_ref: CGColorSpaceRef,
+    bitmap_info: CGBitmapInfo,
+    provider: CGDataProviderRef,
+    decode: ConstPtr<CGFloat>,
+    _should_interpolate: bool,
+    _intent: CGColorRenderingIntent,
+) -> CGImageRef {
+    assert!(decode.is_null());
+    let bytes = cg_data_provider::borrow_bytes(env, provider).to_vec();
+    let byte_order = bitmap_info & kCGBitmapByteOrderMask;
+    let bytes: Vec<u8> = match byte_order {
+        kCGImageByteOrder32Little => {
+            bytes.chunks(4).flat_map(|px| u32::from_le_bytes(px.try_into().unwrap()).to_be_bytes()).collect()
+        }
+        kCGImageByteOrder32Big => {
+            bytes.chunks(4).flat_map(|px| u32::from_be_bytes(px.try_into().unwrap()).to_be_bytes()).collect()
+        }
+        kCGImageByteOrder16Little => {
+            bytes.chunks(2).flat_map(|px| u16::from_le_bytes(px.try_into().unwrap()).to_be_bytes()).collect()
+        }
+        kCGImageByteOrder16Big => {
+            bytes.chunks(2).flat_map(|px| u16::from_be_bytes(px.try_into().unwrap()).to_be_bytes()).collect()
+        }
+        _ => bytes
+    };
+    let alpha = bitmap_info & kCGBitmapAlphaInfoMask;
+    let bytes: Vec<u8> = bytes.chunks(4).flat_map(|px| {
+        let (r, g, b, a) = pixel_offsets_rgb(alpha);
+        let alpha = if let Some(a) = a { px[a] } else { 0 };
+        [px[r], px[g], px[b], alpha]
+    }).collect();
+    from_image(env, Image::from_pixel_vec(bytes.into_iter().collect::<Vec<u8>>(), (width, height), bits_per_pixel / 8))
+}
+
+fn CGImageMaskCreate(
+    env: &mut Environment,
+    width: GuestUSize,
+    height: GuestUSize,
+    _bits_per_component: GuestUSize,
+    _bits_per_pixel: GuestUSize,
+    _bytes_per_row: GuestUSize,
+    provider: CGDataProviderRef,
+    decode: ConstPtr<CGFloat>,
+    _should_interpolate: bool,
+) -> CGImageRef {
+    assert!(decode.is_null());
+    let bytes = cg_data_provider::borrow_bytes(env, provider).to_vec();
+    from_image(env, Image::from_pixel_vec(bytes.to_vec(), (width, height), 1))
+}
+
 fn CGImageCreateCopyWithColorSpace(
     env: &mut Environment,
     image: CGImageRef,
@@ -116,8 +175,8 @@ fn CGImageCreateWithPNGDataProvider(
     env: &mut Environment,
     source: CGDataProviderRef,
     decode: ConstPtr<CGFloat>,
-    _should_interpolate: bool, // TODO
-    _intent: i32,              // TODO (should be CGColorRenderingIntent)
+    _should_interpolate: bool,       // TODO
+    _intent: CGColorRenderingIntent, // TODO (should be CGColorRenderingIntent)
 ) -> CGImageRef {
     assert!(decode.is_null()); // TODO
 
@@ -210,9 +269,11 @@ fn CGImageGetBitsPerComponent(_: &mut Environment, _: CGImageRef) -> GuestUSize 
 pub const FUNCTIONS: FunctionExports = &[
     export_c_func!(CGImageRelease(_)),
     export_c_func!(CGImageRetain(_)),
+    export_c_func!(CGImageCreate(_, _, _, _, _, _, _, _, _, _, _)),
     export_c_func!(CGImageCreateCopyWithColorSpace(_, _)),
     export_c_func!(CGImageCreateWithPNGDataProvider(_, _, _, _)),
     export_c_func!(CGImageCreateWithJPEGDataProvider(_, _, _, _)),
+    export_c_func!(CGImageMaskCreate(_, _, _, _, _, _, _, _)),
     export_c_func!(CGImageGetAlphaInfo(_)),
     export_c_func!(CGImageGetColorSpace(_)),
     export_c_func!(CGImageGetWidth(_)),

--- a/src/frameworks/foundation.rs
+++ b/src/frameworks/foundation.rs
@@ -53,6 +53,7 @@ pub mod ns_url_request;
 pub mod ns_user_defaults;
 pub mod ns_value;
 pub mod ns_xml_parser;
+pub mod ns_keyed_archiver;
 
 pub const DYLIB: crate::dyld::HostDylib = crate::dyld::HostDylib {
     path: "/System/Library/Frameworks/Foundation.framework/Foundation",
@@ -72,6 +73,7 @@ pub const DYLIB: crate::dyld::HostDylib = crate::dyld::HostDylib {
         ns_file_handle::CLASSES,
         ns_file_manager::CLASSES,
         ns_keyed_unarchiver::CLASSES,
+        ns_keyed_archiver::CLASSES,
         ns_locale::CLASSES,
         ns_lock::CLASSES,
         ns_notification::CLASSES,

--- a/src/frameworks/foundation/ns_array.rs
+++ b/src/frameworks/foundation/ns_array.rs
@@ -724,3 +724,8 @@ fn mutable_copy_inner(env: &mut Environment, arr: id) -> id {
     env.objc.borrow_mut::<ArrayHostObject>(mut_arr).array = array;
     mut_arr
 }
+
+pub fn to_vec(env: &Environment, arr: id) -> Vec<id> {
+    let host = env.objc.borrow::<ArrayHostObject>(arr);
+    host.array.to_vec()
+}

--- a/src/frameworks/foundation/ns_keyed_archiver.rs
+++ b/src/frameworks/foundation/ns_keyed_archiver.rs
@@ -1,0 +1,81 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+//! `NSKeyedArchiver` - Currently just a fake implementation.
+
+use crate::objc::{
+    autorelease, id, msg_class, nil, objc_classes, ClassExports, HostObject,
+    NSZonePtr,
+};
+use plist::Dictionary;
+
+struct NSKeyedArchiverHostObject {
+    data: id,
+    plist: Dictionary,
+    /// Something responding to NSKeyedUnarchiverDelegate
+    delegate: id,
+}
+impl HostObject for NSKeyedArchiverHostObject {}
+
+pub const CLASSES: ClassExports = objc_classes! {
+
+(env, this, _cmd);
+
+@implementation NSKeyedArchiver: NSCoder
+
++ (id)allocWithZone:(NSZonePtr)_zone { // struct _NSZone*
+    let archiver = Box::new(NSKeyedArchiverHostObject {
+        delegate: nil,
+        data: nil,
+        plist: Dictionary::new(),
+    });
+    env.objc.alloc_object(this, archiver, &mut env.mem)
+}
+
++ (id)archivedDataWithRootObject:(id)_rootObject { // NSData *
+    let data: id = msg_class![env; NSMutableData new];
+    autorelease(env, data)
+}
+
+// TODO: other init methods.
+
+- (id)initForWritingWithMutableData:(id)data { // NSData *
+    if data == nil {
+        return nil;
+    }
+
+    let host_obj = env.objc.borrow_mut::<NSKeyedArchiverHostObject>(this);
+    assert!(host_obj.data.is_null());
+
+    host_obj.data = data;
+    host_obj.plist = Dictionary::new();
+
+    this
+}
+
+- (())dealloc {
+    env.objc.dealloc_object(this, &mut env.mem)
+}
+
+// TODO: implement calls to delegate methods
+// weak/non-retaining
+- (())setDelegate:(id)delegate { // id<NSKeyedUnarchiverDelegate>
+    let host_object = env.objc.borrow_mut::<NSKeyedArchiverHostObject>(this);
+    host_object.delegate = delegate;
+}
+- (id)delegate {
+    env.objc.borrow::<NSKeyedArchiverHostObject>(this).delegate
+}
+
+- (bool)containsValueForKey:(id)key { // NSString*
+    assert!(key != nil);
+    return false;
+}
+
+// TODO: add more decode methods
+
+@end
+
+};

--- a/src/frameworks/uikit/ui_application.rs
+++ b/src/frameworks/uikit/ui_application.rs
@@ -191,6 +191,10 @@ pub const CLASSES: ClassExports = objc_classes! {
     log!("TODO: ignoring setApplicationIconBadgeNumber:{}", bn);
 }
 
+- (())setApplicationSupportsShakeToEdit:(bool)enable {
+    log!("TODO: ignoring setApplicationSupportsShakeToEdit:{}",enable);
+}
+
 // UIResponder implementation
 // From the Apple UIView docs regarding [UIResponder nextResponder]:
 // "The shared UIApplication object normally returns nil, but it returns its

--- a/src/frameworks/uikit/ui_font.rs
+++ b/src/frameworks/uikit/ui_font.rs
@@ -222,7 +222,7 @@ pub fn size_with_font(
 }
 
 #[inline(always)]
-fn draw_font_glyph(
+pub fn draw_font_glyph(
     drawer: &mut CGBitmapContextDrawer,
     raster_glyph: crate::font::RasterGlyph,
     fill_color: (f32, f32, f32, f32),

--- a/src/frameworks/uikit/ui_graphics.rs
+++ b/src/frameworks/uikit/ui_graphics.rs
@@ -6,11 +6,18 @@
 //! `UIGraphics.h`
 
 use crate::dyld::{export_c_func, FunctionExports};
+use crate::frameworks::core_graphics::cg_bitmap_context::{CGBitmapContextCreate, CGBitmapContextCreateImage};
+use crate::frameworks::core_graphics::cg_color_space::CGColorSpaceCreateDeviceRGB;
 use crate::frameworks::core_graphics::cg_context::{
     CGContextRef, CGContextRelease, CGContextRetain,
 };
-use crate::objc::nil;
-use crate::Environment;
+use crate::frameworks::core_graphics::cg_image::{kCGImageAlphaPremultipliedLast, kCGImageByteOrder32Big};
+use crate::frameworks::core_graphics::CGSize;
+use crate::mem::{GuestUSize, MutVoidPtr};
+use crate::objc::{id, nil};
+use crate::{msg_class, Environment};
+
+pub type UIImageRef = id;
 
 #[derive(Default)]
 pub(super) struct State {
@@ -38,9 +45,32 @@ pub fn UIGraphicsGetCurrentContext(env: &mut Environment) -> CGContextRef {
         .copied()
         .unwrap_or(nil)
 }
+pub fn UIGraphicsBeginImageContext(env: &mut Environment, size: CGSize) {
+    let width = size.width as GuestUSize;
+    let height = size.height as GuestUSize;
+    let color_space = CGColorSpaceCreateDeviceRGB(env);
+    let context = CGBitmapContextCreate(
+        env, MutVoidPtr::null(), width, height, 8, width * 4,
+        color_space,
+        kCGImageByteOrder32Big | kCGImageAlphaPremultipliedLast,
+    );
+    UIGraphicsPushContext(env, context);
+}
+pub fn UIGraphicsEndImageContext(env: &mut Environment) {
+    UIGraphicsPopContext(env);
+}
+
+pub fn UIGraphicsGetImageFromCurrentImageContext(env: &mut Environment) -> UIImageRef {
+    let Some(&context) = env.framework_state.uikit.ui_graphics.context_stack.last() else { return nil; };
+    let cgimage_ref = CGBitmapContextCreateImage(env, context);
+    msg_class![env; UIImage imageWithCGImage: cgimage_ref]
+}
 
 pub const FUNCTIONS: FunctionExports = &[
     export_c_func!(UIGraphicsPushContext(_)),
     export_c_func!(UIGraphicsPopContext()),
     export_c_func!(UIGraphicsGetCurrentContext()),
+    export_c_func!(UIGraphicsBeginImageContext(_)),
+    export_c_func!(UIGraphicsEndImageContext()),
+    export_c_func!(UIGraphicsGetImageFromCurrentImageContext()),
 ];

--- a/src/frameworks/uikit/ui_view.rs
+++ b/src/frameworks/uikit/ui_view.rs
@@ -23,12 +23,10 @@ use crate::frameworks::core_graphics::cg_color::CGColorRef;
 use crate::frameworks::core_graphics::cg_context::{CGContextClearRect, CGContextRef};
 use crate::frameworks::core_graphics::{CGFloat, CGPoint, CGRect, CGSize};
 use crate::frameworks::foundation::ns_string::get_static_str;
-use crate::frameworks::foundation::{ns_array, NSInteger, NSUInteger};
-use crate::objc::{
-    autorelease, id, msg, msg_class, nil, objc_classes, release, retain, Class, ClassExports,
-    HostObject, NSZonePtr, ObjC,
-};
+use crate::frameworks::foundation::{ns_array, NSInteger, NSTimeInterval, NSUInteger};
+use crate::objc::{autorelease, id, msg, msg_class, nil, objc_classes, release, retain, Class, ClassExports, HostObject, NSZonePtr, ObjC, SEL};
 use crate::Environment;
+use crate::mem::MutVoidPtr;
 
 #[derive(Default)]
 pub struct State {
@@ -109,6 +107,18 @@ pub const CLASSES: ClassExports = objc_classes! {
 + (Class)layerClass {
     env.objc.get_known_class("CALayer", &mut env.mem)
 }
+
+
++ (()) beginAnimations: (id)_animationID context: (MutVoidPtr)_context {}
+
++ (()) setAnimationCurve: (NSInteger) _curve {}
++ (()) setAnimationDuration: (NSTimeInterval) _duration {}
++ (()) setAnimationDelay: (NSTimeInterval) _delay {}
++ (()) setAnimationDelegate: (id) _delegate {}
++ (()) setAnimationWillStartSelector: (SEL) _selector {}
++ (()) setAnimationDidStopSelector: (SEL) _selector {}
+
++ (()) commitAnimations {}
 
 // TODO: accessors etc
 

--- a/src/frameworks/uikit/ui_view/ui_control/ui_button.rs
+++ b/src/frameworks/uikit/ui_view/ui_control/ui_button.rs
@@ -391,6 +391,10 @@ pub const CLASSES: ClassExports = objc_classes! {
     }
 }
 
+- (()) setImageEdgeInsets:(CGRect)rect {
+    log!("setImageEdgeInsets: {:?}", rect);
+}
+
 @end
 
 // Undocumented classes used by NIBs

--- a/src/frameworks/uikit/ui_view/ui_scroll_view.rs
+++ b/src/frameworks/uikit/ui_view/ui_scroll_view.rs
@@ -63,6 +63,22 @@ pub const CLASSES: ClassExports = objc_classes! {
     // TODO
 }
 
+- (())setPagingEnabled:(bool)_enabled {
+    // TODO
+}
+
+- (())setShowsHorizontalScrollIndicator:(bool)_enabled {
+    // TODO
+}
+
+- (())setShowsVerticalScrollIndicator:(bool)_enabled {
+    // TODO
+}
+
+- (())setScrollsToTop:(bool)_enabled {
+    // TODO
+}
+
 - (bool)scrollEnabled {
     env.objc.borrow::<UIScrollViewHostObject>(this).scroll_enabled
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -25,6 +25,7 @@ use touchHLE_stb_image_wrapper::*;
 pub struct Image {
     pixels: PixelStore,
     dimensions: (u32, u32),
+    bytes_per_pixel: u32,
 }
 
 enum PixelStore {
@@ -88,16 +89,18 @@ impl Image {
         Ok(Image {
             pixels: PixelStore::StbImage(pixels),
             dimensions: (width, height),
+            bytes_per_pixel: 4,
         })
     }
 
     /// TODO: This shouldn't really exist, it's a workaround for `CGImage`
     /// relying on this type and should be removed once it can be refactored.
-    pub fn from_pixel_vec(pixels: Vec<u8>, dimensions: (u32, u32)) -> Image {
-        assert!(dimensions.0 as usize * 4 * dimensions.1 as usize == pixels.len());
+    pub fn from_pixel_vec(pixels: Vec<u8>, dimensions: (u32, u32), bpp: u32) -> Image {
+        assert!(dimensions.0 as usize * bpp as usize * dimensions.1 as usize == pixels.len());
         Image {
             pixels: PixelStore::Vec(pixels),
             dimensions,
+            bytes_per_pixel: bpp,
         }
     }
 
@@ -222,7 +225,7 @@ impl Clone for Image {
     fn clone(&self) -> Image {
         // Note: implicitly converts pixel storage from StbImage to Vec
         // (if needed)
-        Image::from_pixel_vec(self.pixels().to_vec(), self.dimensions)
+        Image::from_pixel_vec(self.pixels().to_vec(), self.dimensions, self.bytes_per_pixel)
     }
 }
 

--- a/src/libc/mach/time.rs
+++ b/src/libc/mach/time.rs
@@ -38,7 +38,7 @@ fn mach_timebase_info(
 /// The result of this function, multiplied by the constant from
 /// [mach_timebase_info], should be the absolute time in nanoseconds.
 /// The absolute time is a monotonic clock with an arbitrary starting point.
-fn mach_absolute_time(env: &mut Environment) -> u64 {
+pub fn mach_absolute_time(env: &mut Environment) -> u64 {
     let now = Instant::now();
     now.duration_since(env.startup_time)
         .as_nanos()

--- a/src/objc.rs
+++ b/src/objc.rs
@@ -42,7 +42,7 @@ pub use selectors::{selector, SEL};
 
 use crate::mem::ConstVoidPtr;
 use crate::Environment;
-use classes::{ClassHostObject, FakeClass, UnimplementedClass};
+use classes::{ClassHostObject, FakeClass, UnimplementedClass, objc_getClass, object_getClass};
 use messages::{
     objc_msgSend, objc_msgSendSuper2, objc_msgSend_stret, MsgSendSignature, MsgSendSuperSignature,
 };
@@ -135,5 +135,7 @@ const FUNCTIONS: FunctionExports = &[
     export_c_func!(objc_sync_enter(_)),
     export_c_func!(objc_sync_exit(_)),
     export_c_func!(sel_registerName(_)),
+    export_c_func!(objc_getClass(_)),
+    export_c_func!(object_getClass(_)),
     export_c_func!(_Block_object_dispose(_, _)),
 ];

--- a/src/objc.rs
+++ b/src/objc.rs
@@ -42,7 +42,10 @@ pub use selectors::{selector, SEL};
 
 use crate::mem::ConstVoidPtr;
 use crate::Environment;
-use classes::{ClassHostObject, FakeClass, UnimplementedClass, objc_getClass, object_getClass};
+use classes::{
+    ClassHostObject, FakeClass, UnimplementedClass, objc_getClass, object_getClass,
+    class_getSuperclass,
+};
 use messages::{
     objc_msgSend, objc_msgSendSuper2, objc_msgSend_stret, MsgSendSignature, MsgSendSuperSignature,
 };
@@ -137,5 +140,6 @@ const FUNCTIONS: FunctionExports = &[
     export_c_func!(sel_registerName(_)),
     export_c_func!(objc_getClass(_)),
     export_c_func!(object_getClass(_)),
+    export_c_func!(class_getSuperclass(_)),
     export_c_func!(_Block_object_dispose(_, _)),
 ];

--- a/src/objc.rs
+++ b/src/objc.rs
@@ -45,6 +45,7 @@ use crate::Environment;
 use classes::{
     ClassHostObject, FakeClass, UnimplementedClass, objc_getClass, object_getClass,
     class_getSuperclass,
+    class_getInstanceMethod, method_getImplementation, method_setImplementation,
 };
 use messages::{
     objc_msgSend, objc_msgSendSuper2, objc_msgSend_stret, MsgSendSignature, MsgSendSuperSignature,
@@ -141,5 +142,8 @@ const FUNCTIONS: FunctionExports = &[
     export_c_func!(objc_getClass(_)),
     export_c_func!(object_getClass(_)),
     export_c_func!(class_getSuperclass(_)),
+    export_c_func!(class_getInstanceMethod(_, _)),
+    export_c_func!(method_getImplementation(_)),
+    export_c_func!(method_setImplementation(_, _)),
     export_c_func!(_Block_object_dispose(_, _)),
 ];

--- a/src/objc/classes.rs
+++ b/src/objc/classes.rs
@@ -953,6 +953,12 @@ pub(super) fn objc_getClass(env: &mut Environment, name: ConstPtr<u8>) -> Class 
     env.objc.link_class(&name, /* is_metaclass: */ false, &mut env.mem)
 }
 
+/// Standard Objective-C runtime function for getting a class's superclass.
+pub(super) fn class_getSuperclass(env: &mut Environment, class: Class) -> Class {
+    let obj: &ClassHostObject = env.objc.get_host_object(class.cast()).unwrap().as_any().downcast_ref().unwrap();
+    obj.superclass
+}
+
 /// Standard Objective-C runtime function for getting the class of an object.
 pub(super) fn object_getClass(env: &mut Environment, obj: id) -> Class {
     if obj == nil {

--- a/src/objc/classes.rs
+++ b/src/objc/classes.rs
@@ -354,11 +354,23 @@ impl ClassHostObject {
                     template.instance_methods
                 })
                 .iter()
-                .map(|&(name, host_imp)| {
+                .flat_map(|&(name, host_imp)| {
+                    // handle cases like functionWithControlPoints:::: 
+                    // where multiple objc arguments without verb exist,
+                    // which rust macro can't handle
+                    let sanitized_name = name
+                        .split(':')
+                        .map(|c| if c.starts_with('_') {""} else {c})
+                        .collect::<Vec<&str>>()
+                        .join(":");
+
                     // The selector should already have been registered by
                     // [ObjC::register_host_selectors], so we can panic
                     // if it hasn't been.
-                    (objc.selectors[name], IMP::Host(host_imp))
+                    [
+                        (objc.selectors[name], IMP::Host(host_imp)),
+                        (objc.selectors[sanitized_name.as_str()], IMP::Host(host_imp))
+                    ]
                 }),
             ),
             // maybe this should be 0 for NSObject? does it matter?

--- a/src/objc/classes.rs
+++ b/src/objc/classes.rs
@@ -432,7 +432,8 @@ fn substitute_classes(
         || name.starts_with("Mobclix")
         || name.starts_with("FB") // Facebook
         || name.starts_with("Flurry")
-        || name.starts_with("OpenFeint"))
+        || name.starts_with("OpenFeint")
+        || name.starts_with("Tapjoy"))
     {
         return None;
     }

--- a/src/objc/classes.rs
+++ b/src/objc/classes.rs
@@ -18,6 +18,7 @@ use crate::mach_o::MachO;
 use crate::mem::{guest_size_of, ConstPtr, ConstVoidPtr, GuestUSize, Mem, Ptr, SafeRead};
 use crate::Environment;
 use std::collections::{HashMap, VecDeque};
+use crate::abi::GuestFunction;
 
 /// Generic pointer to an Objective-C class or metaclass.
 ///
@@ -965,4 +966,68 @@ pub(super) fn object_getClass(env: &mut Environment, obj: id) -> Class {
         return nil;
     }
     ObjC::read_isa(obj, &env.mem)
+}
+
+/// Opaque type that represents method of a class. 
+/// Currently represented by combination of a class and a selector name.
+pub(super) struct MethodRef(Class, SEL);
+unsafe impl SafeRead for MethodRef {}
+
+/// Standard Objective-C runtime function for getting 
+/// an opaque pointer to a class instance method.
+pub(super) fn class_getInstanceMethod(env: &mut Environment, class: Class, name: SEL) -> ConstPtr<MethodRef> {
+    let obj: &ClassHostObject = env.objc.get_host_object(class.cast()).unwrap().as_any().downcast_ref().unwrap();
+    let opt = obj.methods.iter().find(|&(method, _i)| method.eq(&name));
+    let str_name = name.as_str(&env.mem);
+    if opt.is_none() {
+        if obj.superclass != nil {
+            return class_getInstanceMethod(env, obj.superclass, name);
+        }
+        log!("Method {}::{} not found!", obj.name, str_name);
+        return ConstPtr::null();
+    }
+    env.mem.alloc_and_write(MethodRef(class, name)).cast_const()
+}
+
+/// Standard Objective-C runtime function for getting 
+/// a function pointer to a class instance method.
+pub(super) fn method_getImplementation(env: &mut Environment, method: ConstPtr<MethodRef>) -> ConstVoidPtr {
+    let method = env.mem.read(method);
+    get_implementation_ptr(env, method)
+}
+
+fn get_implementation_ptr(env: &mut Environment, method: MethodRef) -> ConstVoidPtr {
+    let (class, name) = (method.0, method.1);
+    let obj: &ClassHostObject = env.objc.get_host_object(class.cast()).unwrap().as_any().downcast_ref().unwrap();
+    let opt = obj.methods.iter().find(|&(method, _i)| method.eq(&name));
+    let str_name = name.as_str(&env.mem);
+    let ptr = match opt {
+        None => {
+            panic!("Method {}::{} not found!", obj.name, str_name)
+        }
+        Some((_, imp)) => {
+            match imp {
+                IMP::Host(host_implementation) => {
+                    env.dyld.create_guest_hostimp(&mut env.mem, "HostFN", *host_implementation).to_ptr()
+                }
+                IMP::Guest(guest_implementation) => {
+                    guest_implementation.to_ptr()
+                }
+            }
+        }
+    };
+    log_dbg!("Returning pointer to: {:#x}", ptr.to_bits());
+    ptr
+}
+
+/// Standard Objective-C runtime function for replacing a 
+/// class instance method with a custom implementation.
+pub(super) fn method_setImplementation(env: &mut Environment, method: ConstPtr<MethodRef>, imp: ConstVoidPtr) -> ConstVoidPtr {
+    let method = env.mem.read(method);
+    let (class, name) = (method.0, method.1);
+    let old = get_implementation_ptr(env, method);
+    let obj: &mut ClassHostObject = env.objc.borrow_mut(class.cast());
+    obj.methods.remove(&name);
+    obj.methods.insert(name, IMP::Guest(GuestFunction::from_addr_with_thumb_bit(imp.to_bits())));
+    old
 }

--- a/src/objc/classes.rs
+++ b/src/objc/classes.rs
@@ -16,6 +16,7 @@ use super::{
 };
 use crate::mach_o::MachO;
 use crate::mem::{guest_size_of, ConstPtr, ConstVoidPtr, GuestUSize, Mem, Ptr, SafeRead};
+use crate::Environment;
 use std::collections::{HashMap, VecDeque};
 
 /// Generic pointer to an Objective-C class or metaclass.
@@ -937,4 +938,24 @@ impl ObjC {
             None
         }
     }
+}
+
+/// Standard Objective-C runtime function for getting a class by name.
+/// If the class doesn't exist yet, it will create an [UnimplementedClass]
+/// placeholder instead.
+pub(super) fn objc_getClass(env: &mut Environment, name: ConstPtr<u8>) -> Class {
+    if name.is_null() {
+        return nil;
+    }
+    let name = env.mem.cstr_at_utf8(name).unwrap().to_string();
+    // Use link_class to ensure missing classes are created as placeholders
+    env.objc.link_class(&name, /* is_metaclass: */ false, &mut env.mem)
+}
+
+/// Standard Objective-C runtime function for getting the class of an object.
+pub(super) fn object_getClass(env: &mut Environment, obj: id) -> Class {
+    if obj == nil {
+        return nil;
+    }
+    ObjC::read_isa(obj, &env.mem)
 }

--- a/src/objc/classes.rs
+++ b/src/objc/classes.rs
@@ -649,10 +649,16 @@ impl ObjC {
                 .unwrap()
                 .as_any()
                 .downcast_ref();
-            let Some(ClassHostObject { superclass, .. }) = class_host_object else {
+            let Some(ClassHostObject { superclass, methods, ivars, .. }) = class_host_object else {
                 // Skip FakeClass or UnimplementedClass
                 continue;
             };
+
+            if methods.is_empty() && ivars.is_empty() {
+                // Skip classes with no methods or attributes, 
+                // these seem to be loading with null superclass?
+                continue;
+            }
 
             if *superclass != nil {
                 inverted_inheritance

--- a/src/objc/selectors.rs
+++ b/src/objc/selectors.rs
@@ -104,6 +104,19 @@ impl ObjC {
         {
             for method_list in [template.class_methods, template.instance_methods] {
                 for &(name, _imp) in method_list {
+                    // handle cases like functionWithControlPoints::::
+                    // where multiple objc arguments without verb exist,
+                    // which rust macro can't handle
+                    let sanitized_name = name
+                        .split(':')
+                        .map(|c| if c.starts_with('_') {""} else {c})
+                        .collect::<Vec<&str>>()
+                        .join(":");
+                    if sanitized_name.as_str() != name 
+                        && !self.selectors.contains_key(sanitized_name.as_str()) {
+                        let sel = SEL(mem.alloc_and_write_cstr(sanitized_name.as_bytes()).cast_const());
+                        self.selectors.insert(sanitized_name.as_str().to_string(), sel);
+                    }
                     if self.selectors.contains_key(name) {
                         continue;
                     }


### PR DESCRIPTION
Reopening #445:
Hi!
This PR implements some stuff that's required to get Cause of Death booting:
- method_getImplementation / method_setImplementation / object_getClass
- CGFont (requires ttf-parser which was already an indirect dependency)
- CATransform
- general mocks of missing methods in other classes
- allow CFRunLoopTimerCreate's context_ptr to be null (allowed according to [Apple docs](https://developer.apple.com/documentation/corefoundation/cfrunlooptimercreate(_:_:_:_:_:_:_:)?language=objc), see "context" parameter
- rewrite selector names when text before colon is underscored (some selectors don't have text before colon but rust macro apparently can't handle it?)
- Implementing a couple more constants in CAAnimation and CATransform allows the game to boot without ignoring null dereferences
- Implementing CAKeyframeAnimation allows the game to progress to the main menu, where some buttons are not rendering and pressing them complains about unimplemented methods in UIScrollView