### PR TITLE
Allow right analog stick mapping and tilt controls

### DIFF
--- a/OPTIONS_HELP.txt
+++ b/OPTIONS_HELP.txt
@@ -44,7 +44,8 @@ Device options:
         Accepted values are "iphone" and "ipad" respectively.
 
 Game controller options:
-    --deadzone=...
+    --left_deadzone=...
+    --right_deadzone=...
         Configures the size of the \"dead zone\" for analog stick inputs.
 
         The default value is 0.1, which means that 10% of the stick's range on

--- a/OPTIONS_HELP.txt
+++ b/OPTIONS_HELP.txt
@@ -54,20 +54,21 @@ Game controller options:
 
         This is a floating-point (decimal) number between 0 and 1.
 
-    --disable-analog-stick-tilt-controls
-        Disables mapping of analog stick input to simulated rotation of the
-        device.
+    --analog-stick-tilt-controls=...
+        Configures which analog stick will be used for tilt controls.
 
-        By default, if touchHLE detects a game controller, its analog sticks
+        By default, if touchHLE detects a game controller, its left analog stick
         will be used for simulated accelerometer tilt controls. When this
         happens, the real accelerometer (e.g. on an Android phone), if present,
-        is ignored. By setting this option, the real accelerometer can be used
+        is ignored. By setting this option to none, the real accelerometer can be used
         even if a game controller is detected. This may be useful on a device
         that integrates both an accelerometer and a game controller, or if you
         do not want to disconnect your game controller.
 
         Note that touchHLE does not currently support accelerometers contained
         within game controllers.
+
+        Accepted values are "none", "left" and "right".
 
     --x-tilt-range=...
     --y-tilt-range=...

--- a/OPTIONS_HELP.txt
+++ b/OPTIONS_HELP.txt
@@ -113,8 +113,8 @@ Game controller options:
         part of the screen.
 
         This is three parts separated by commas: the name of a button (DPadLeft,
-        DPadUp, DPadRight, DPadDown, Start, LeftShoulder or Xbox-like
-        A, B, X or Y), the X co-ordinate and the Y co-ordinate.
+        DPadUp, DPadRight, DPadDown, Start, LeftShoulder, RightShoulder,
+        or Xbox-like A, B, X or Y), the X co-ordinate and the Y co-ordinate.
         The co-ordinates are floating-point (decimal) numbers. 0,0 is the
         top-left corner. The bottom-right corner is 320,480 if the app is in
         portrait, and 480,320 if the app is in landscape.
@@ -148,8 +148,9 @@ Game controller options:
         right analog stick (tap/hold by pressing the stick or right shoulder
         button).
 
-    --stick-to-touch=...
-        Maps the left analog stick to simulated finger movement within a region
+    --left-stick-to-touch=...
+    --right-stick-to-touch=...
+        Maps the analog stick to simulated finger movement within a region
         of the simulated touch screen of the device. This is useful for games
         which use analog movement controls.
 
@@ -158,9 +159,12 @@ Game controller options:
         bottom-right corner is 320,480 if the app is in portrait, and 480,320
         if the app is in landscape.
 
-        For example, --stick-to-touch=10,10,100,100 will map the left analog
+        For example, --left-stick-to-touch=10,10,100,100 will map the left analog
         stick to control a touch within a 100x100 pixel region starting at
         (10,10) on the screen.
+
+        If --right-stick-to-touch is set, its virtual cursor function is disabled,
+        allowing for right analog stick to be mapped in twin-stick shooters.
 
         Except where specified in touchHLE_default_options.txt, this is not used
         by default. There is however a virtual cursor that is controlled by the

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Input methods:
 - For simulated touch input, there are four options:
   - Mouse/trackpad input (tap/hold/drag by pressing the left mouse button)
   - Virtual cursor using a game controller (move the cursor with the right analog stick, and tap/hold/drag by pressing the stick or the right shoulder button)
-  - Mapping of game controller buttons or the left analog stick to specific on-screen locations (see the descriptions of `--button-to-touch=`, `--dpad-to-touch=` and `--stick-to-touch=` in `OPTIONS_HELP.txt`)
+  - Mapping of game controller buttons or the analog sticks to specific on-screen locations (see the descriptions of `--button-to-touch=`, `--dpad-to-touch=`, `--left-stick-to-touch=` and `--right-stick-to-touch=` in `OPTIONS_HELP.txt`)
   - Real touch input, if you're on a device that has a touch screen
 - For simulated accelerometer input, there are three options:
   - Tilt control simulation using the left analog stick of a game controller

--- a/src/environment/app_picker.rs
+++ b/src/environment/app_picker.rs
@@ -30,7 +30,7 @@ use crate::fs::BundleData;
 use crate::image::Image;
 use crate::mem::Ptr;
 use crate::objc::{id, msg, msg_class, nil, objc_classes, release, ClassExports, HostObject};
-use crate::options::Options;
+use crate::options::{Options, TiltControlsStick};
 use crate::paths;
 use crate::window::DeviceOrientation;
 use crate::Environment;
@@ -146,7 +146,9 @@ struct AppPickerDelegateHostObject {
     orientation_portrait_upside_down: bool,
     orientation_landscape_left: bool,
     orientation_landscape_right: bool,
-    analog_stick_tilt_controls: Option<bool>,
+    analog_stick_tilt_controls_none: bool,
+    analog_stick_tilt_controls_left: bool,
+    analog_stick_tilt_controls_right: bool,
     network: Option<bool>,
     fullscreen: Option<bool>,
 }
@@ -225,9 +227,14 @@ const CLASSES: ClassExports = objc_classes! {
 - (())orientationLandscapeRight {
     env.objc.borrow_mut::<AppPickerDelegateHostObject>(this).orientation_landscape_right = true;
 }
-- (())analogStickTiltControls:(id)switch { // UISwitch*
-    let switch_state: bool = msg![env; switch isOn];
-    env.objc.borrow_mut::<AppPickerDelegateHostObject>(this).analog_stick_tilt_controls = Some(switch_state);
+- (())analogStickTiltControlsNone {
+    env.objc.borrow_mut::<AppPickerDelegateHostObject>(this).analog_stick_tilt_controls_none = true;
+}
+- (())analogStickTiltControlsLeft {
+    env.objc.borrow_mut::<AppPickerDelegateHostObject>(this).analog_stick_tilt_controls_left = true;
+}
+- (())analogStickTiltControlsRight {
+    env.objc.borrow_mut::<AppPickerDelegateHostObject>(this).analog_stick_tilt_controls_right = true;
 }
 - (())network:(id)switch { // UISwitch*
     let switch_state: bool = msg![env; switch isOn];
@@ -530,7 +537,7 @@ fn app_picker_inner(
     let mut quick_options_scale_hack: Option<NonZeroU32> = None;
     let mut quick_options_fullscreen: Option<()> = None;
     let mut quick_options_orientation: Option<DeviceOrientation> = None;
-    let mut quick_options_analog_stick_tilt_controls = true;
+    let mut quick_options_analog_stick_tilt_controls: Option<TiltControlsStick> = None;
     let mut quick_options_network = false;
 
     fn update_quick_option_buttons(env: &mut Environment, buttons: &[id], selected_idx: usize) {
@@ -562,6 +569,13 @@ fn app_picker_inner(
             }),
         );
     }
+    fn update_analog_stick_tilt_controls_buttons(env: &mut Environment, buttons: &[id], value: Option<TiltControlsStick>) {
+        update_quick_option_buttons(env, buttons, value.map_or(1, |v| match v {
+            TiltControlsStick::None => 0,
+            TiltControlsStick::Left => 1,
+            TiltControlsStick::Right => 2,
+        }),);
+    }
     update_scale_hack_buttons(
         env,
         &quick_options_stuff.scale_hack_buttons,
@@ -571,6 +585,11 @@ fn app_picker_inner(
         env,
         &quick_options_stuff.orientation_buttons,
         quick_options_orientation,
+    );
+    update_analog_stick_tilt_controls_buttons(
+        env,
+        &quick_options_stuff.analog_stick_tilt_controls_buttons,
+        quick_options_analog_stick_tilt_controls
     );
 
     () = msg![env; window makeKeyAndVisible];
@@ -710,8 +729,27 @@ fn app_picker_inner(
                 &quick_options_stuff.orientation_buttons,
                 quick_options_orientation,
             );
-        } else if let Some(enabled) = std::mem::take(&mut host_obj.analog_stick_tilt_controls) {
-            quick_options_analog_stick_tilt_controls = enabled;
+        } else if std::mem::take(&mut host_obj.analog_stick_tilt_controls_none) {
+            quick_options_analog_stick_tilt_controls = Some(TiltControlsStick::None);
+            update_analog_stick_tilt_controls_buttons(
+                env,
+                &quick_options_stuff.analog_stick_tilt_controls_buttons,
+                quick_options_analog_stick_tilt_controls,
+            );
+        } else if std::mem::take(&mut host_obj.analog_stick_tilt_controls_left) {
+            quick_options_analog_stick_tilt_controls = Some(TiltControlsStick::Left);
+            update_analog_stick_tilt_controls_buttons(
+                env,
+                &quick_options_stuff.analog_stick_tilt_controls_buttons,
+                quick_options_analog_stick_tilt_controls,
+            );
+        } else if std::mem::take(&mut host_obj.analog_stick_tilt_controls_right) {
+            quick_options_analog_stick_tilt_controls = Some(TiltControlsStick::Right);
+            update_analog_stick_tilt_controls_buttons(
+                env,
+                &quick_options_stuff.analog_stick_tilt_controls_buttons,
+                quick_options_analog_stick_tilt_controls,
+            );
         } else if let Some(enabled) = std::mem::take(&mut host_obj.network) {
             quick_options_network = enabled;
         } else if let Some(fullscreen) = std::mem::take(&mut host_obj.fullscreen) {
@@ -737,11 +775,11 @@ fn app_picker_inner(
             .to_string(),
         );
     }
+    if let Some(analog_stick_tilt_controls) = quick_options_analog_stick_tilt_controls {
+        option_args.push(format!("--analog-stick-tilt-controls={}", analog_stick_tilt_controls.to_string().to_lowercase()));
+    }
     if let Some(()) = quick_options_fullscreen {
         option_args.push("--fullscreen".to_string());
-    }
-    if !quick_options_analog_stick_tilt_controls {
-        option_args.push("--disable-analog-stick-tilt-controls".to_string());
     }
     if quick_options_network {
         option_args.push("--allow-network-access".to_string());
@@ -1264,6 +1302,7 @@ struct QuickOptionsStuff {
     main_view: id,
     scale_hack_buttons: [id; 5],
     orientation_buttons: [id; 4],
+    analog_stick_tilt_controls_buttons: [id; 3],
 }
 
 fn setup_quick_options(
@@ -1343,10 +1382,14 @@ fn setup_quick_options(
             ("→", "orientationLandscapeRight"),
             ("↓", "orientationPortraitUpsideDown"),
         ]),
+        RowKind::Label("Use analog stick for tilt controls"),
+        RowKind::Buttons(&[
+            ("None", "analogStickTiltControlsNone"),
+            ("Left", "analogStickTiltControlsLeft"),
+            ("Right", "analogStickTiltControlsRight"),
+        ]),
         RowKind::Label("Network access"),
         RowKind::Switch("network:", false),
-        RowKind::Label("Use analog sticks for tilt controls"),
-        RowKind::Switch("analogStickTiltControls:", true),
         // ---- (divider for stuff skipped below)
         RowKind::Label("Fullscreen (override)"),
         RowKind::Switch("fullscreen:", false),
@@ -1421,5 +1464,6 @@ fn setup_quick_options(
         main_view,
         scale_hack_buttons: button_rows[0][..].try_into().unwrap(),
         orientation_buttons: button_rows[1][..].try_into().unwrap(),
+        analog_stick_tilt_controls_buttons: button_rows[2][..].try_into().unwrap(),
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -38,7 +38,8 @@ pub struct Options {
     pub device_family: Option<DeviceFamily>,
     pub initial_orientation: DeviceOrientation,
     pub scale_hack: NonZeroU32,
-    pub deadzone: f32,
+    pub left_deadzone: f32,
+    pub right_deadzone: f32,
     pub analog_stick_tilt_controls: bool,
     pub x_tilt_range: f32,
     pub y_tilt_range: f32,
@@ -72,7 +73,8 @@ impl Default for Options {
             initial_orientation: DeviceOrientation::Portrait,
             scale_hack: NonZeroU32::new(1).unwrap(),
             analog_stick_tilt_controls: true,
-            deadzone: 0.1,
+            left_deadzone: 0.1,
+            right_deadzone: 0.1,
             x_tilt_range: 60.0,
             y_tilt_range: 60.0,
             x_tilt_offset: 0.0,
@@ -132,8 +134,10 @@ impl Options {
                 .map_err(|_| "Invalid scale hack factor".to_string())?;
         } else if arg == "--disable-analog-stick-tilt-controls" {
             self.analog_stick_tilt_controls = false;
-        } else if let Some(value) = arg.strip_prefix("--deadzone=") {
-            self.deadzone = parse_degrees(value, "deadzone")?;
+        } else if let Some(value) = arg.strip_prefix("--left-deadzone=") {
+            self.left_deadzone = parse_degrees(value, "left stick deadzone")?;
+        } else if let Some(value) = arg.strip_prefix("--right-deadzone=") {
+            self.right_deadzone = parse_degrees(value, "right stick deadzone")?;
         } else if let Some(value) = arg.strip_prefix("--x-tilt-range=") {
             self.x_tilt_range = parse_degrees(value, "X tilt range")?;
         } else if let Some(value) = arg.strip_prefix("--y-tilt-range=") {

--- a/src/options.rs
+++ b/src/options.rs
@@ -32,6 +32,19 @@ pub enum Button {
     RightShoulder,
 }
 
+/// Game controller analog stick as tilt controls for `--analog-stick-tilt-controls=` option.
+#[derive(Copy, Clone, Hash, PartialEq, Eq, Debug)]
+pub enum TiltControlsStick {
+    None,
+    Left,
+    Right
+}
+impl std::fmt::Display for TiltControlsStick {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
+    }
+}
+
 /// Struct containing all user-configurable options.
 #[derive(Clone)]
 pub struct Options {
@@ -41,7 +54,7 @@ pub struct Options {
     pub scale_hack: NonZeroU32,
     pub left_deadzone: f32,
     pub right_deadzone: f32,
-    pub analog_stick_tilt_controls: bool,
+    pub analog_stick_tilt_controls: TiltControlsStick,
     pub x_tilt_range: f32,
     pub y_tilt_range: f32,
     pub x_tilt_offset: f32,
@@ -74,7 +87,7 @@ impl Default for Options {
             device_family: None,
             initial_orientation: DeviceOrientation::Portrait,
             scale_hack: NonZeroU32::new(1).unwrap(),
-            analog_stick_tilt_controls: true,
+            analog_stick_tilt_controls: TiltControlsStick::Left,
             left_deadzone: 0.1,
             right_deadzone: 0.1,
             x_tilt_range: 60.0,
@@ -135,8 +148,12 @@ impl Options {
             self.scale_hack = value
                 .parse()
                 .map_err(|_| "Invalid scale hack factor".to_string())?;
-        } else if arg == "--disable-analog-stick-tilt-controls" {
-            self.analog_stick_tilt_controls = false;
+        } else if let Some(value) = arg.strip_prefix("--analog-stick-tilt-controls=") {
+            self.analog_stick_tilt_controls = match value {
+                "none" => TiltControlsStick::None,
+                "right" => TiltControlsStick::Right,
+                _ => TiltControlsStick::Left
+            };
         } else if let Some(value) = arg.strip_prefix("--left-deadzone=") {
             self.left_deadzone = parse_degrees(value, "left stick deadzone")?;
         } else if let Some(value) = arg.strip_prefix("--right-deadzone=") {

--- a/src/options.rs
+++ b/src/options.rs
@@ -78,6 +78,7 @@ pub struct Options {
     pub dumping_file: PathBuf,
     pub ignore_gl_errors: bool,
     pub zero_stack_after_guest_to_host_call: Option<u32>,
+    pub hide_cursor: bool,
 }
 
 impl Default for Options {
@@ -113,6 +114,7 @@ impl Default for Options {
             dumping_file: crate::paths::user_data_base_path().join("DUMP.txt"),
             ignore_gl_errors: false,
             zero_stack_after_guest_to_host_call: None,
+            hide_cursor: false,
         }
     }
 }
@@ -154,6 +156,7 @@ impl Options {
                 "right" => TiltControlsStick::Right,
                 _ => TiltControlsStick::Left
             };
+            self.hide_cursor = self.analog_stick_tilt_controls == TiltControlsStick::Right;
         } else if let Some(value) = arg.strip_prefix("--left-deadzone=") {
             self.left_deadzone = parse_degrees(value, "left stick deadzone")?;
         } else if let Some(value) = arg.strip_prefix("--right-deadzone=") {
@@ -214,6 +217,7 @@ impl Options {
                 .map_err(|_| "--right-stick-to-touch= requires four values".to_string())?;
 
             self.right_stick_to_touch = Some((nums[0], nums[1], nums[2], nums[3]));
+            self.hide_cursor = true;
         } else if let Some(values) = arg.strip_prefix("--dpad-to-touch=") {
             let nums: [f32; 4] = values
                 .split(',')

--- a/src/options.rs
+++ b/src/options.rs
@@ -29,6 +29,7 @@ pub enum Button {
     X,
     Y,
     LeftShoulder,
+    RightShoulder,
 }
 
 /// Struct containing all user-configurable options.
@@ -47,7 +48,8 @@ pub struct Options {
     pub y_tilt_offset: f32,
     pub button_to_touch: HashMap<Button, (f32, f32)>,
     pub dpad_to_touch: Option<(f32, f32, f32, f32)>,
-    pub stick_to_touch: Option<(f32, f32, f32, f32)>,
+    pub left_stick_to_touch: Option<(f32, f32, f32, f32)>,
+    pub right_stick_to_touch: Option<(f32, f32, f32, f32)>,
     pub stabilize_virtual_cursor: Option<(f32, f32)>,
     pub gles1_implementation: Option<GLESImplementation>,
     pub direct_memory_access: bool,
@@ -81,7 +83,8 @@ impl Default for Options {
             y_tilt_offset: 0.0,
             button_to_touch: HashMap::new(),
             dpad_to_touch: None,
-            stick_to_touch: None,
+            left_stick_to_touch: None,
+            right_stick_to_touch: None,
             stabilize_virtual_cursor: None,
             gles1_implementation: None,
             direct_memory_access: true,
@@ -164,6 +167,7 @@ impl Options {
                 "X" => Ok(Button::X),
                 "Y" => Ok(Button::Y),
                 "LeftShoulder" => Ok(Button::LeftShoulder),
+                "RightShoulder" => Ok(Button::RightShoulder),
                 _ => Err("Invalid button for --button-to-touch=".to_string()),
             }?;
             let x: f32 = x
@@ -173,16 +177,26 @@ impl Options {
                 .parse()
                 .map_err(|_| "Invalid Y co-ordinate for --button-to-touch=".to_string())?;
             self.button_to_touch.insert(button, (x, y));
-        } else if let Some(values) = arg.strip_prefix("--stick-to-touch=") {
+        } else if let Some(values) = arg.strip_prefix("--left-stick-to-touch=") {
             let nums: [f32; 4] = values
                 .split(',')
                 .map(|s| s.parse::<f32>())
                 .collect::<Result<Vec<_>, _>>()
-                .map_err(|_| "invalid --stick-to-touch".to_string())?
+                .map_err(|_| "invalid --left-stick-to-touch".to_string())?
                 .try_into()
-                .map_err(|_| "--stick-to-touch= requires four values".to_string())?;
+                .map_err(|_| "--left-stick-to-touch= requires four values".to_string())?;
 
-            self.stick_to_touch = Some((nums[0], nums[1], nums[2], nums[3]));
+            self.left_stick_to_touch = Some((nums[0], nums[1], nums[2], nums[3]));
+        } else if let Some(values) = arg.strip_prefix("--right-stick-to-touch=") {
+            let nums: [f32; 4] = values
+                .split(',')
+                .map(|s| s.parse::<f32>())
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| "invalid --right-stick-to-touch".to_string())?
+                .try_into()
+                .map_err(|_| "--right-stick-to-touch= requires four values".to_string())?;
+
+            self.right_stick_to_touch = Some((nums[0], nums[1], nums[2], nums[3]));
         } else if let Some(values) = arg.strip_prefix("--dpad-to-touch=") {
             let nums: [f32; 4] = values
                 .split(',')

--- a/src/window.rs
+++ b/src/window.rs
@@ -682,7 +682,7 @@ impl Window {
                     if axis == sdl2::controller::Axis::LeftX
                         || axis == sdl2::controller::Axis::LeftY
                     {
-                        let (stick_x, stick_y, _) = self.get_controller_stick(options, true);
+                        let (stick_x, stick_y, _) = self.get_controller_stick(options.left_deadzone, true);
                         let coords = transform_input_coords(
                             self,
                             (
@@ -691,7 +691,7 @@ impl Window {
                             ),
                             true,
                         );
-                        if stick_x.abs() < options.deadzone && stick_y.abs() < options.deadzone {
+                        if stick_x.abs() < options.left_deadzone && stick_y.abs() < options.left_deadzone {
                             if !self.stick_active {
                                 // Ignore deadzone events when stick is inactive
                                 continue;
@@ -963,7 +963,7 @@ impl Window {
                 .unwrap()
         } else {
             // Get left analog stick input. The range is [-1, 1] on each axis.
-            let (x, y, _) = self.get_controller_stick(options, true);
+            let (x, y, _) = self.get_controller_stick(options.left_deadzone, true);
             (x, y)
         };
 
@@ -1022,7 +1022,7 @@ impl Window {
     /// and whether the cursor moved.
     fn update_virtual_cursor(&mut self, options: &Options) -> (f32, f32, bool, bool, bool) {
         // Get right analog stick input. The range is [-1, 1] on each axis.
-        let (x, y, pressed) = self.get_controller_stick(options, false);
+        let (x, y, pressed) = self.get_controller_stick(options.right_deadzone, false);
 
         // The cursor is intended to only show up once you move the analog stick
         // out of its deadzone, or while the button is held.
@@ -1108,7 +1108,7 @@ impl Window {
     /// Get the summed X and Y positions and button state of the left or right
     /// analog stick of the game controllers. Each axis value is in the range
     /// [-1, 1].
-    fn get_controller_stick(&self, options: &Options, left: bool) -> (f32, f32, bool) {
+    fn get_controller_stick(&self, deadzone: f32, left: bool) -> (f32, f32, bool) {
         fn convert_axis(axis: i16, deadzone: f32) -> f32 {
             assert!(deadzone >= 0.0);
             let axis = ((axis as f32) / (i16::MAX as f32)).clamp(-1.0, 1.0);
@@ -1135,8 +1135,8 @@ impl Window {
                     Button::RightShoulder,
                 )
             };
-            x += convert_axis(controller.axis(x_axis), options.deadzone);
-            y += convert_axis(controller.axis(y_axis), options.deadzone);
+            x += convert_axis(controller.axis(x_axis), deadzone);
+            y += convert_axis(controller.axis(y_axis), deadzone);
             pressed |= controller.button(button1);
             pressed |= controller.button(button2);
         }

--- a/src/window.rs
+++ b/src/window.rs
@@ -918,10 +918,7 @@ impl Window {
             log!("ignoring fingerprint device: {}", controller_name);
             return;
         }
-        log!(
-            "New controller connected: {}. Left stick = device tilt. Right stick = touch input (press the stick or shoulder button to tap/hold).",
-            controller_name
-        );
+        log!("New controller connected: {}.", controller_name);
         self.controllers.push(controller);
     }
     fn controller_removed(&mut self, instance_id: u32) {

--- a/src/window.rs
+++ b/src/window.rs
@@ -877,7 +877,7 @@ impl Window {
             })
         }
 
-        if controller_updated && options.right_stick_to_touch.is_none() && options.analog_stick_tilt_controls != TiltControlsStick::Right {
+        if controller_updated && !options.hide_cursor {
             let (new_x, new_y, pressed, pressed_changed, moved) =
                 self.update_virtual_cursor(options);
             self.event_queue

--- a/src/window.rs
+++ b/src/window.rs
@@ -16,7 +16,7 @@ use crate::gles::present::present_frame;
 use crate::gles::{create_gles1_ctx_no_parent_stack, GLESContext, GLES};
 use crate::image::Image;
 use crate::matrix::Matrix;
-use crate::options::Options;
+use crate::options::{Options, TiltControlsStick};
 use crate::Environment;
 use sdl2::mouse::MouseButton;
 use sdl2::pixels::PixelFormatEnum;
@@ -877,7 +877,7 @@ impl Window {
             })
         }
 
-        if options.right_stick_to_touch.is_none() && controller_updated {
+        if controller_updated && options.right_stick_to_touch.is_none() && options.analog_stick_tilt_controls != TiltControlsStick::Right {
             let (new_x, new_y, pressed, pressed_changed, moved) =
                 self.update_virtual_cursor(options);
             self.event_queue
@@ -933,26 +933,28 @@ impl Window {
         log!("Warning: Controller disconnected: {}", controller.name());
     }
     pub fn print_accelerometer_notice(&self, options: &Options) {
+        let hasTiltStick = options.analog_stick_tilt_controls != TiltControlsStick::None;
+
         log!("This app uses the accelerometer.");
 
-        if !self.controllers.is_empty() && options.analog_stick_tilt_controls {
-            log!("Your connected controller's left analog stick will be used for accelerometer simulation.");
+        if !self.controllers.is_empty() && hasTiltStick {
+            log!("Your connected controller's analog stick will be used for accelerometer simulation.");
             if self.accelerometer.is_some() {
                 log!("Disconnect the controller if you want to use your device's accelerometer.");
             }
         } else if self.accelerometer.is_some() {
             log!("Your device's accelerometer will be used for accelerometer simulation.");
-            if options.analog_stick_tilt_controls {
+            if hasTiltStick {
                 log!("Connect a controller if you would prefer to use an analog stick.");
             }
-        } else if self.controllers.is_empty() && options.analog_stick_tilt_controls {
+        } else if self.controllers.is_empty() && hasTiltStick {
             log!("Connect a controller to get accelerometer simulation.");
         }
 
         if self.accelerometer.is_none() {
             log!(
                 "You can {}hold right click and move the cursor to simulate the accelerometer.",
-                if options.analog_stick_tilt_controls {
+                if hasTiltStick {
                     "also "
                 } else {
                     ""
@@ -964,7 +966,7 @@ impl Window {
     /// Get the real or simulated accelerometer output.
     /// See also [crate::frameworks::uikit::ui_accelerometer].
     pub fn get_acceleration(&self, options: &Options) -> (f32, f32, f32) {
-        if self.controllers.is_empty() || !options.analog_stick_tilt_controls {
+        if self.controllers.is_empty() || options.analog_stick_tilt_controls == TiltControlsStick::None {
             if let Some(ref accelerometer) = self.accelerometer {
                 let data = accelerometer.get_data().unwrap();
                 let sdl2::sensor::SensorData::Accel(data) = data else {
@@ -980,6 +982,8 @@ impl Window {
                 let (x, y, z) = (x / gravity, y / gravity, z / gravity);
                 return (x, y, z);
             }
+
+            return (0.0, 0.0, -1.0);
         }
 
         let (x, y) = if self
@@ -990,8 +994,13 @@ impl Window {
                 .map(|(x, y, _right_click_hold)| (x, y))
                 .unwrap()
         } else {
-            // Get left analog stick input. The range is [-1, 1] on each axis.
-            let (x, y, _) = self.get_controller_stick(options.left_deadzone, true);
+            // Get analog stick input. The range is [-1, 1] on each axis.
+            let isLeftStick = options.analog_stick_tilt_controls == TiltControlsStick::Left;
+            let (x, y, _) = self.get_controller_stick(if isLeftStick {
+                options.left_deadzone
+            } else {
+                options.right_deadzone
+            }, isLeftStick);
             (x, y)
         };
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -127,7 +127,8 @@ pub enum FingerId {
     Touch(i64),
     VirtualCursor,
     ButtonToTouch(crate::options::Button),
-    StickToTouch,
+    LeftStickToTouch,
+    RightStickToTouch,
     DpadToTouch,
 }
 pub type Coords = (f32, f32);
@@ -236,7 +237,8 @@ pub struct Window {
     controller_ctx: sdl2::GameControllerSubsystem,
     controllers: Vec<sdl2::controller::GameController>,
     dpad_state: DpadState,
-    stick_active: bool,
+    left_stick_active: bool,
+    right_stick_active: bool,
     _sensor_ctx: sdl2::SensorSubsystem,
     accelerometer: Option<sdl2::sensor::Sensor>,
     virtual_cursor_last: Option<(f32, f32, bool, bool)>,
@@ -391,7 +393,8 @@ impl Window {
                 down: false,
                 active: false,
             },
-            stick_active: false,
+            left_stick_active: false,
+            right_stick_active: false,
             _sensor_ctx: sensor_ctx,
             accelerometer,
             virtual_cursor_last: None,
@@ -479,9 +482,8 @@ impl Window {
                 sdl2::controller::Button::B => Some(crate::options::Button::B),
                 sdl2::controller::Button::X => Some(crate::options::Button::X),
                 sdl2::controller::Button::Y => Some(crate::options::Button::Y),
-                sdl2::controller::Button::LeftShoulder => {
-                    Some(crate::options::Button::LeftShoulder)
-                }
+                sdl2::controller::Button::LeftShoulder => Some(crate::options::Button::LeftShoulder),
+                sdl2::controller::Button::RightShoulder => Some(crate::options::Button::RightShoulder),
                 _ => None,
             }
         }
@@ -676,12 +678,11 @@ impl Window {
                 }
                 E::ControllerAxisMotion { axis, .. } => {
                     controller_updated = true;
-                    let Some((x, y, w, h)) = options.stick_to_touch else {
-                        continue;
-                    };
-                    if axis == sdl2::controller::Axis::LeftX
-                        || axis == sdl2::controller::Axis::LeftY
-                    {
+
+                    if axis == sdl2::controller::Axis::LeftX || axis == sdl2::controller::Axis::LeftY {
+                        let Some((x, y, w, h)) = options.left_stick_to_touch else {
+                            continue
+                        };
                         let (stick_x, stick_y, _) = self.get_controller_stick(options.left_deadzone, true);
                         let coords = transform_input_coords(
                             self,
@@ -692,21 +693,51 @@ impl Window {
                             true,
                         );
                         if stick_x.abs() < options.left_deadzone && stick_y.abs() < options.left_deadzone {
-                            if !self.stick_active {
+                            if !self.left_stick_active {
                                 // Ignore deadzone events when stick is inactive
                                 continue;
                             } else {
                                 // Release touch when stick returns to deadzone
-                                self.stick_active = false;
-                                Event::TouchesUp(HashMap::from([(FingerId::StickToTouch, coords)]))
+                                self.left_stick_active = false;
+                                Event::TouchesUp(HashMap::from([(FingerId::LeftStickToTouch, coords)]))
                             }
-                        } else if !self.stick_active {
+                        } else if !self.left_stick_active {
                             // New touch
-                            self.stick_active = true;
-                            Event::TouchesDown(HashMap::from([(FingerId::StickToTouch, coords)]))
+                            self.left_stick_active = true;
+                            Event::TouchesDown(HashMap::from([(FingerId::LeftStickToTouch, coords)]))
                         } else {
                             // Move existing touch
-                            Event::TouchesMove(HashMap::from([(FingerId::StickToTouch, coords)]))
+                            Event::TouchesMove(HashMap::from([(FingerId::LeftStickToTouch, coords)]))
+                        }
+                    } else if axis == sdl2::controller::Axis::RightX || axis == sdl2::controller::Axis::RightY {
+                        let Some((x, y, w, h)) = options.right_stick_to_touch else {
+                            continue
+                        };
+                        let (stick_x, stick_y, _) = self.get_controller_stick(options.right_deadzone, false);
+                        let coords = transform_input_coords(
+                            self,
+                            (
+                                x + ((stick_x + 1.0) / 2.0) * w,
+                                y + ((stick_y + 1.0) / 2.0) * h,
+                            ),
+                            true,
+                        );
+                        if stick_x.abs() < options.right_deadzone && stick_y.abs() < options.right_deadzone {
+                            if !self.right_stick_active {
+                                // Ignore deadzone events when stick is inactive
+                                continue;
+                            } else {
+                                // Release touch when stick returns to deadzone
+                                self.right_stick_active = false;
+                                Event::TouchesUp(HashMap::from([(FingerId::RightStickToTouch, coords)]))
+                            }
+                        } else if !self.right_stick_active {
+                            // New touch
+                            self.right_stick_active = true;
+                            Event::TouchesDown(HashMap::from([(FingerId::RightStickToTouch, coords)]))
+                        } else {
+                            // Move existing touch
+                            Event::TouchesMove(HashMap::from([(FingerId::RightStickToTouch, coords)]))
                         }
                     } else {
                         continue;
@@ -846,7 +877,7 @@ impl Window {
             })
         }
 
-        if controller_updated {
+        if options.right_stick_to_touch.is_none() && controller_updated {
             let (new_x, new_y, pressed, pressed_changed, moved) =
                 self.update_virtual_cursor(options);
             self.event_queue

--- a/touchHLE_default_options.txt
+++ b/touchHLE_default_options.txt
@@ -210,7 +210,7 @@ jp.co.capcom.residentevil.en: --landscape-left --stabilize-virtual-cursor=0.1,10
 
 # COD Zombies
 # DPad/Stick = Move, Left shoulder = Knife, A = Shoot, B = Aim, X = Reload, Y = Grenade, Start = Pause
-com.activision.callofduty: --x-tilt-offset=-10 --dpad-to-touch=30,215,80,80 --left-stick-to-touch=30,215,80,80 --button-to-touch=A,387,210 --button-to-touch=B,455,185 --button-to-touch=X,455,25 --button-to-touch=Y,440,95 --button-to-touch=LeftShoulder,240,310 --button-to-touch=Start,20,25
+com.activision.callofduty: --y-tilt-offset=45 --dpad-to-touch=30,215,80,80 --left-stick-to-touch=30,215,80,80 --button-to-touch=A,387,210 --button-to-touch=B,455,185 --button-to-touch=X,455,25 --button-to-touch=Y,440,95 --button-to-touch=LeftShoulder,240,310 --button-to-touch=Start,20,25
 
 # Pandemonium
 # DPad/Stick = Move, Up = Switch Character, X = Fargus Attack, A = Fire, B = Jump, LeftShoulder = Switch Camera, Start = Pause

--- a/touchHLE_default_options.txt
+++ b/touchHLE_default_options.txt
@@ -83,7 +83,7 @@ com.darxun.motoracinggp: --landscape-right --button-to-touch=A,25,295 --button-t
 com.bestsungame.warriornationblade:  --button-to-touch=DPadLeft,50,285 --button-to-touch=DPadRight,120,285 --button-to-touch=A,430,260 --button-to-touch=B,440,185 --button-to-touch=X,360,280 --button-to-touch=Y,230,270 --button-to-touch=LeftShoulder,270,30 --button-to-touch=Start,460,20
 
 # Resident Evil 4
-jp.co.capcom.res4: --landscape-left --stabilize-virtual-cursor=0.1,10 --button-to-touch=A,430,280 --button-to-touch=B,440,200 --button-to-touch=X,360,200 --button-to-touch=Y,440,150 --dpad-to-touch=25,200,95,100 --stick-to-touch=25,200,95,100
+jp.co.capcom.res4: --landscape-left --stabilize-virtual-cursor=0.1,10 --button-to-touch=A,430,280 --button-to-touch=B,440,200 --button-to-touch=X,360,200 --button-to-touch=Y,440,150 --dpad-to-touch=25,200,95,100 --left-stick-to-touch=25,200,95,100
 
 # Earthworm Jim
 # Dpad = Move, A = Jump, B = Whip, X = Fire
@@ -152,13 +152,13 @@ com.activision.CBNK2: --landscape-left
 
 # FIFA 10
 # Stick/Dpad = Move, A = Pass/Tackle, B,LeftShoulder = Shoot/Switch players, Start = Pause
-com.ea.fifa10.bv: --landscape-left --button-to-touch=A,450,206 --button-to-touch=B,430,270 --button-to-touch=LeftShoulder,430,270 --button-to-touch=Start,160,16 --dpad-to-touch=25,195,100,100 --stick-to-touch=25,195,100,100
-com.ea.fifa10inc: --landscape-left --button-to-touch=A,450,206 --button-to-touch=B,430,270 --button-to-touch=LeftShoulder,430,270 --button-to-touch=Start,160,16 --dpad-to-touch=25,195,100,100 --stick-to-touch=25,195,100,100
+com.ea.fifa10.bv: --landscape-left --button-to-touch=A,450,206 --button-to-touch=B,430,270 --button-to-touch=LeftShoulder,430,270 --button-to-touch=Start,160,16 --dpad-to-touch=25,195,100,100 --left-stick-to-touch=25,195,100,100
+com.ea.fifa10inc: --landscape-left --button-to-touch=A,450,206 --button-to-touch=B,430,270 --button-to-touch=LeftShoulder,430,270 --button-to-touch=Start,160,16 --dpad-to-touch=25,195,100,100 --left-stick-to-touch=25,195,100,100
 
 # FIFA 2010 WORLD CUP SOUTH AFRICA
 # Stick = Move, A,LeftShoulder = Pass/Tackle/Switch players, B = Shoot/Slide, X = Skill, Start = Pause
-com.ea.fifa10wc.bv: --landscape-left --button-to-touch=A,414,174 --button-to-touch=B,328,256 --button-to-touch=LeftShoulder,414,174 --button-to-touch=X,436,276 --button-to-touch=Start,160,16 --stick-to-touch=25,195,100,100
-com.ea.fifa10wc.inc: --landscape-left --button-to-touch=A,414,174 --button-to-touch=B,328,256 --button-to-touch=LeftShoulder,414,174 --button-to-touch=X,436,276 --button-to-touch=Start,160,16 --stick-to-touch=25,195,100,100
+com.ea.fifa10wc.bv: --landscape-left --button-to-touch=A,414,174 --button-to-touch=B,328,256 --button-to-touch=LeftShoulder,414,174 --button-to-touch=X,436,276 --button-to-touch=Start,160,16 --left-stick-to-touch=25,195,100,100
+com.ea.fifa10wc.inc: --landscape-left --button-to-touch=A,414,174 --button-to-touch=B,328,256 --button-to-touch=LeftShoulder,414,174 --button-to-touch=X,436,276 --button-to-touch=Start,160,16 --left-stick-to-touch=25,195,100,100
 
 # Real Racing
 com.firemint.realracing: --landscape-left
@@ -174,7 +174,7 @@ com.pangea.bug2: --ignore-gl-errors
 
 # Rayman 2
 # Stick = Move, A = Jump, X = Shoot/Skip cutscene, Y = First-person, B = Dive
-com.gameloft.Rayman2: --stick-to-touch=22,210,90,100 --button-to-touch=A,376,280 --button-to-touch=X,435,220 --button-to-touch=Y,22,88 --button-to-touch=B,448,144 --button-to-touch=Start,16,16
+com.gameloft.Rayman2: --left-stick-to-touch=22,210,90,100 --button-to-touch=A,376,280 --button-to-touch=X,435,220 --button-to-touch=Y,22,88 --button-to-touch=B,448,144 --button-to-touch=Start,16,16
 
 # Casper
 # (force composition fixes graphical issues)
@@ -190,7 +190,7 @@ com.gameloft.BIA: --landscape-left --zero-stack-after-guest-to-host-call=25
 
 # Hero of Sparta II
 # Stick = Move, A = Jump, B = Quick attack, X = Block, Y = Weapon select, LeftShoulder = Focus kill
-com.gameloft.HOS2: --stick-to-touch=28,206,84,84 --button-to-touch=Start,25,25 --button-to-touch=B,394,234 --button-to-touch=A,456,190 --button-to-touch=X,350,294 --button-to-touch=Y,434,22 --button-to-touch=LeftShoulder,446,286
+com.gameloft.HOS2: --left-stick-to-touch=28,206,84,84 --button-to-touch=Start,25,25 --button-to-touch=B,394,234 --button-to-touch=A,456,190 --button-to-touch=X,350,294 --button-to-touch=Y,434,22 --button-to-touch=LeftShoulder,446,286
 
 # Unity's 3D World demo
 com.unity3d.3Dworld: --landscape-left --force-composition
@@ -206,11 +206,11 @@ com.namconetworks.AceCombatXi: --landscape-left --y-tilt-offset=45 --button-to-t
 com.mrgoodliving.TikiTowers: --landscape-left
 
 # Resident Evil Degeneration
-jp.co.capcom.residentevil.en: --landscape-left --stabilize-virtual-cursor=0.1,10 --button-to-touch=A,430,280 --button-to-touch=B,440,200 --button-to-touch=Y,440,100 --button-to-touch=Start,30,30 --dpad-to-touch=25,200,95,100 --stick-to-touch=25,200,95,100
+jp.co.capcom.residentevil.en: --landscape-left --stabilize-virtual-cursor=0.1,10 --button-to-touch=A,430,280 --button-to-touch=B,440,200 --button-to-touch=Y,440,100 --button-to-touch=Start,30,30 --dpad-to-touch=25,200,95,100 --left-stick-to-touch=25,200,95,100
 
 # COD Zombies
 # DPad/Stick = Move, Left shoulder = Knife, A = Shoot, B = Aim, X = Reload, Y = Grenade, Start = Pause
-com.activision.callofduty: --x-tilt-offset=-10 --dpad-to-touch=30,215,80,80 --stick-to-touch=30,215,80,80 --button-to-touch=A,387,210 --button-to-touch=B,455,185 --button-to-touch=X,455,25 --button-to-touch=Y,440,95 --button-to-touch=LeftShoulder,240,310 --button-to-touch=Start,20,25
+com.activision.callofduty: --x-tilt-offset=-10 --dpad-to-touch=30,215,80,80 --left-stick-to-touch=30,215,80,80 --button-to-touch=A,387,210 --button-to-touch=B,455,185 --button-to-touch=X,455,25 --button-to-touch=Y,440,95 --button-to-touch=LeftShoulder,240,310 --button-to-touch=Start,20,25
 
 # Pandemonium
 # DPad/Stick = Move, Up = Switch Character, X = Fargus Attack, A = Fire, B = Jump, LeftShoulder = Switch Camera, Start = Pause


### PR DESCRIPTION
closes #545 

depends on: #630 

+ true twin-stick experience for games that support it, like waw.
+ add right shoulder button, because now we can make good use of it when --right-stick-to-touch is set.
+ fix waw tilt controls
+ introduce --analog-stick-tilt-controls option (none, left, right) to assign tilt controls to the preferred analog stick
+ remove now obsolete --disable-analog-stick-tilt-controls option
+ fix --analog-stick-tilt-controls=none (old --disable-analog-stick-tilt-controls) not being respected

updated quick settings
<img width="320" height="480" alt="ui" src="https://github.com/user-attachments/assets/2567c9ec-8d53-4c04-b697-1bc924d5b08a" />


tested on arch, waw, xbox 360 controller

settings:

r1 shoot, l1 aim, sticks move/camera, other buttons same as #629 
```
com.activision.callofduty: --analog-stick-tilt-controls=none --left-stick-to-touch=30,215,80,80 --right-stick-to-touch=375,220,80,80 --button-to-touch=RightShoulder,380,200 --button-to-touch=LeftShoulder,455,185 --button-to-touch=X,455,25 --button-to-touch=Y,440,95 --button-to-touch=RightStick,240,310 --button-to-touch=Back,240,240 --button-to-touch=Start,20,25
```

set twin-stick controls in game settings.


tilt settings:
```
com.activision.callofduty: --analog-stick-tilt-controls=right --y-tilt-offset=45 --left-stick-to-touch=30,215,80,80  --button-to-touch=RightShoulder,380,200 --button-to-touch=LeftShoulder,455,185 --button-to-touch=X,455,25 --button-to-touch=Y,440,95 --button-to-touch=RightStick,240,310 --button-to-touch=Back,240,240 --button-to-touch=Start,20,25
```

set tilt controls in game settings
swap x/y axis